### PR TITLE
feat: implement multiple Coach beans with @Qualifier injection

### DIFF
--- a/02-spring-boot-spring-core/04-qualifiers/.gitattributes
+++ b/02-spring-boot-spring-core/04-qualifiers/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/02-spring-boot-spring-core/04-qualifiers/.gitignore
+++ b/02-spring-boot-spring-core/04-qualifiers/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/02-spring-boot-spring-core/04-qualifiers/pom.xml
+++ b/02-spring-boot-spring-core/04-qualifiers/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>np.com.krishna-bk</groupId>
+    <artifactId>springcoredemo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>04-qualifiers</name>
+    <description>04-qualifiers</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/Application.java
+++ b/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/Application.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.springcoredemo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/common/BaseballCoach.java
+++ b/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/common/BaseballCoach.java
@@ -1,0 +1,11 @@
+package np.com.krishnabk.springcoredemo.common;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class BaseballCoach implements Coach{
+    @Override
+    public String getDailyWorkout() {
+        return "Spend 30 minutes in batting practice.";
+    }
+}

--- a/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/common/Coach.java
+++ b/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/common/Coach.java
@@ -1,0 +1,5 @@
+package np.com.krishnabk.springcoredemo.common;
+
+public interface Coach {
+    String getDailyWorkout();
+}

--- a/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/common/CricketCoach.java
+++ b/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/common/CricketCoach.java
@@ -1,0 +1,11 @@
+package np.com.krishnabk.springcoredemo.common;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class CricketCoach implements Coach{
+    @Override
+    public String getDailyWorkout() {
+        return "Practice fast bowling for 15 minutes";
+    }
+}

--- a/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/common/TennisCoach.java
+++ b/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/common/TennisCoach.java
@@ -1,0 +1,11 @@
+package np.com.krishnabk.springcoredemo.common;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TennisCoach implements Coach{
+    @Override
+    public String getDailyWorkout() {
+        return "Practice your backhand volley";
+    }
+}

--- a/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/common/TrackCoach.java
+++ b/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/common/TrackCoach.java
@@ -1,0 +1,11 @@
+package np.com.krishnabk.springcoredemo.common;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TrackCoach implements Coach{
+    @Override
+    public String getDailyWorkout() {
+        return "Run a hard 5k!";
+    }
+}

--- a/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/rest/DemoController.java
+++ b/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/rest/DemoController.java
@@ -2,6 +2,8 @@ package np.com.krishnabk.springcoredemo.rest;
 
 import np.com.krishnabk.springcoredemo.common.Coach;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,7 +15,7 @@ public class DemoController {
 
     // define a setter for dependency injection
     @Autowired
-    public DemoController(Coach theCoach) {
+    public DemoController(@Qualifier("tennisCoach") Coach theCoach) {
         myCoach = theCoach;
     }
 

--- a/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/rest/DemoController.java
+++ b/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/rest/DemoController.java
@@ -3,7 +3,6 @@ package np.com.krishnabk.springcoredemo.rest;
 import np.com.krishnabk.springcoredemo.common.Coach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Primary;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,7 +12,7 @@ public class DemoController {
     // define a private field for dependency
     private Coach myCoach;
 
-    // define a setter for dependency injection
+    // define a constructor for dependency injection
     @Autowired
     public DemoController(@Qualifier("tennisCoach") Coach theCoach) {
         myCoach = theCoach;

--- a/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/rest/DemoController.java
+++ b/02-spring-boot-spring-core/04-qualifiers/src/main/java/np/com/krishnabk/springcoredemo/rest/DemoController.java
@@ -1,0 +1,25 @@
+package np.com.krishnabk.springcoredemo.rest;
+
+import np.com.krishnabk.springcoredemo.common.Coach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DemoController {
+
+    // define a private field for dependency
+    private Coach myCoach;
+
+    // define a setter for dependency injection
+    @Autowired
+    public DemoController(Coach theCoach) {
+        myCoach = theCoach;
+    }
+
+    // expose endpoint
+    @GetMapping("/dailyworkout")
+    public String getDailyWorkout(){
+        return myCoach.getDailyWorkout();
+    }
+}

--- a/02-spring-boot-spring-core/04-qualifiers/src/main/resources/application.properties
+++ b/02-spring-boot-spring-core/04-qualifiers/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=04-qualifiers

--- a/02-spring-boot-spring-core/04-qualifiers/src/test/java/np/com/krishnabk/springcoredemo/ApplicationTests.java
+++ b/02-spring-boot-spring-core/04-qualifiers/src/test/java/np/com/krishnabk/springcoredemo/ApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.springcoredemo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
- Added multiple Coach implementations: BaseballCoach, TennisCoach, TrackCoach, and CricketCoach.

- Used @qualifier annotation to inject specific beans into DemoController.

- Demonstrated how to resolve ambiguity in Spring's dependency injection when multiple beans of the same type are available.