### PR TITLE
feat: demonstrate lazy initialization in Spring Boot

### DIFF
--- a/02-spring-boot-spring-core/06-lazy-initialization/.gitattributes
+++ b/02-spring-boot-spring-core/06-lazy-initialization/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/02-spring-boot-spring-core/06-lazy-initialization/.gitignore
+++ b/02-spring-boot-spring-core/06-lazy-initialization/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/02-spring-boot-spring-core/06-lazy-initialization/pom.xml
+++ b/02-spring-boot-spring-core/06-lazy-initialization/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>np.com.krishna-bk</groupId>
+    <artifactId>springcoredemo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>06-lazy-initialization</name>
+    <description>06-lazy-initialization</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/Application.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/Application.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.springcoredemo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/BaseballCoach.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/BaseballCoach.java
@@ -5,6 +5,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class BaseballCoach implements Coach{
+
+    public BaseballCoach(){
+        System.out.println("In Constructor: " + getClass().getSimpleName());
+    }
+
     @Override
     public String getDailyWorkout() {
         return "Spend 30 minutes in batting practice.";

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/BaseballCoach.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/BaseballCoach.java
@@ -1,0 +1,12 @@
+package np.com.krishnabk.springcoredemo.common;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BaseballCoach implements Coach{
+    @Override
+    public String getDailyWorkout() {
+        return "Spend 30 minutes in batting practice.";
+    }
+}

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/Coach.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/Coach.java
@@ -1,0 +1,5 @@
+package np.com.krishnabk.springcoredemo.common;
+
+public interface Coach {
+    String getDailyWorkout();
+}

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/CricketCoach.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/CricketCoach.java
@@ -4,6 +4,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class CricketCoach implements Coach{
+
+    public CricketCoach(){
+        System.out.println("In Constructor: " + getClass().getSimpleName());
+    }
+
     @Override
     public String getDailyWorkout() {
         return "Practice fast bowling for 15 minutes";

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/CricketCoach.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/CricketCoach.java
@@ -1,0 +1,11 @@
+package np.com.krishnabk.springcoredemo.common;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class CricketCoach implements Coach{
+    @Override
+    public String getDailyWorkout() {
+        return "Practice fast bowling for 15 minutes";
+    }
+}

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/TennisCoach.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/TennisCoach.java
@@ -4,6 +4,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class TennisCoach implements Coach{
+
+    public TennisCoach(){
+        System.out.println("In Constructor: " + getClass().getSimpleName());
+    }
+
     @Override
     public String getDailyWorkout() {
         return "Practice your backhand volley";

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/TennisCoach.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/TennisCoach.java
@@ -1,0 +1,11 @@
+package np.com.krishnabk.springcoredemo.common;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TennisCoach implements Coach{
+    @Override
+    public String getDailyWorkout() {
+        return "Practice your backhand volley";
+    }
+}

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/TrackCoach.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/TrackCoach.java
@@ -4,6 +4,11 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class TrackCoach implements Coach{
+
+    public TrackCoach(){
+        System.out.println("In Constructor: " + getClass().getSimpleName());
+    }
+
     @Override
     public String getDailyWorkout() {
         return "Run a hard 5k!";

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/TrackCoach.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/TrackCoach.java
@@ -1,0 +1,11 @@
+package np.com.krishnabk.springcoredemo.common;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TrackCoach implements Coach{
+    @Override
+    public String getDailyWorkout() {
+        return "Run a hard 5k!";
+    }
+}

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/TrackCoach.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/common/TrackCoach.java
@@ -1,8 +1,10 @@
 package np.com.krishnabk.springcoredemo.common;
 
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 @Component
+@Lazy
 public class TrackCoach implements Coach{
 
     public TrackCoach(){

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/rest/DemoController.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/rest/DemoController.java
@@ -15,6 +15,7 @@ public class DemoController {
     // define a constructor for dependency injection
     @Autowired
     public DemoController(@Qualifier("cricketCoach") Coach theCoach) {
+        System.out.println("In Constructor: " + getClass().getSimpleName());
         myCoach = theCoach;
     }
 

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/rest/DemoController.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/java/np/com/krishnabk/springcoredemo/rest/DemoController.java
@@ -1,0 +1,26 @@
+package np.com.krishnabk.springcoredemo.rest;
+
+import np.com.krishnabk.springcoredemo.common.Coach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DemoController {
+
+    // define a private field for dependency
+    private Coach myCoach;
+
+    // define a constructor for dependency injection
+    @Autowired
+    public DemoController(@Qualifier("cricketCoach") Coach theCoach) {
+        myCoach = theCoach;
+    }
+
+    // expose endpoint
+    @GetMapping("/dailyworkout")
+    public String getDailyWorkout(){
+        return myCoach.getDailyWorkout();
+    }
+}

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/resources/application.properties
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=06-lazy-initialization

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/main/resources/application.properties
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=06-lazy-initialization
+
+spring.main.lazy-initialization=true

--- a/02-spring-boot-spring-core/06-lazy-initialization/src/test/java/np/com/krishnabk/springcoredemo/ApplicationTests.java
+++ b/02-spring-boot-spring-core/06-lazy-initialization/src/test/java/np/com/krishnabk/springcoredemo/ApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.springcoredemo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
- Initialize a new project for lazy initialization demo
- Add constructors to all coach classes to log instantiation
- Make TrachCoach bean lazy-initialized using `@Lazy` annotation
- Enable global lazy initialization via application.properties

![image](https://github.com/user-attachments/assets/23df5605-3c3a-4060-a53b-3019e4cb3886)
