### PR TITLE
feat: implement update and delete operations for Student entity using JPA

### DIFF
--- a/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/CruddemoApplication.java
+++ b/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/CruddemoApplication.java
@@ -27,7 +27,9 @@ public class CruddemoApplication {
 
 //            queryForStudents(studentDAO);
 
-              queryForStudentsByLastName(studentDAO);
+//            queryForStudentsByLastName(studentDAO);
+
+              updateStudent(studentDAO);
         };
     }
 

--- a/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/CruddemoApplication.java
+++ b/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/CruddemoApplication.java
@@ -29,8 +29,19 @@ public class CruddemoApplication {
 
 //              queryForStudentsByLastName(studentDAO);
 
-              updateStudent(studentDAO);
+//              updateStudent(studentDAO);
+
+            deleteStudent(studentDAO);
         };
+    }
+
+    private void deleteStudent(StudentDAO studentDAO) {
+        // retrieve student based on the id: primary key
+        int studentId = 1;
+        System.out.println("Deleting student id: " + studentId);
+
+        // delete the student
+        studentDAO.delete(studentId);
     }
 
     private void updateStudent(StudentDAO studentDAO) {

--- a/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/CruddemoApplication.java
+++ b/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/CruddemoApplication.java
@@ -19,18 +19,36 @@ public class CruddemoApplication {
     @Bean
     public CommandLineRunner commandLineRunner(StudentDAO studentDAO){
         return runner -> {
-//            createStudent(studentDAO);
+//              createStudent(studentDAO);
 
-//            createMultipleStudents(studentDAO);
+//              createMultipleStudents(studentDAO);
 
-//            readStudent(studentDAO);
+//              readStudent(studentDAO);
 
-//            queryForStudents(studentDAO);
+//              queryForStudents(studentDAO);
 
-//            queryForStudentsByLastName(studentDAO);
+//              queryForStudentsByLastName(studentDAO);
 
               updateStudent(studentDAO);
         };
+    }
+
+    private void updateStudent(StudentDAO studentDAO) {
+
+        // retrieve student based on the id: Primary Key
+        int studentId = 2;
+        System.out.println("Getting student with studentId: " + studentId);
+        Student theStudent = studentDAO.findById(studentId);
+
+        // change first name to "Ram"
+        System.out.println("Updating student ...");
+        theStudent.setFirstName("Ram");
+
+        // update the student
+        studentDAO.update(theStudent);
+
+        // display the updated student
+        System.out.println("Updated student: " + theStudent);
     }
 
     private void queryForStudentsByLastName(StudentDAO studentDAO) {

--- a/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/CruddemoApplication.java
+++ b/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/CruddemoApplication.java
@@ -43,6 +43,7 @@ public class CruddemoApplication {
         // change first name to "Ram"
         System.out.println("Updating student ...");
         theStudent.setFirstName("Ram");
+        theStudent.setEmail("ram@krishna-bk.com.np");
 
         // update the student
         studentDAO.update(theStudent);

--- a/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAO.java
+++ b/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAO.java
@@ -15,4 +15,6 @@ public interface StudentDAO {
     List<Student> findByLastName(String theLastName);
 
     void update(Student theStudent);
+
+    void delete(Integer id);
 }

--- a/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAO.java
+++ b/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAO.java
@@ -13,4 +13,6 @@ public interface StudentDAO {
     List<Student> findAll();
 
     List<Student> findByLastName(String theLastName);
+
+    void update(Student theStudent);
 }

--- a/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAOImpl.java
+++ b/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAOImpl.java
@@ -61,4 +61,15 @@ public class StudentDAOImpl implements StudentDAO{
     public void update(Student theStudent) {
         entityManager.merge(theStudent);
     }
+
+    @Override
+    @Transactional
+    public void delete(Integer id) {
+
+        // retrieve the student
+        Student theStudent = entityManager.find(Student.class, id);
+
+        // delete the student
+        entityManager.remove(id);
+    }
 }

--- a/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAOImpl.java
+++ b/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAOImpl.java
@@ -70,6 +70,6 @@ public class StudentDAOImpl implements StudentDAO{
         Student theStudent = entityManager.find(Student.class, id);
 
         // delete the student
-        entityManager.remove(id);
+        entityManager.remove(theStudent);
     }
 }

--- a/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAOImpl.java
+++ b/03-spring-boot-hibernate-jpa-crud/01-crud-demo-student/src/main/java/np/com/krishnabk/cruddemo/dao/StudentDAOImpl.java
@@ -55,4 +55,10 @@ public class StudentDAOImpl implements StudentDAO{
         // return query results
         return theQuery.getResultList();
     }
+
+    @Override
+    @Transactional
+    public void update(Student theStudent) {
+        entityManager.merge(theStudent);
+    }
 }


### PR DESCRIPTION
This PR adds support for updating and deleting student records through the DAO layer, completing the CRUD operations.

What's Included:

1. Update Functionality:

- Defined updateStudent(Student student) in StudentDAO

- Implemented the update logic using entityManager.merge()

- Updated a student's name and email as part of the application flow

2. Delete Functionality:

- Defined and implemented the delete(int id) method in DAO

- Fixed a critical issue by passing the correct entity reference to the entityManager.remove()

- Added logic in the main app to delete a student by ID

Why?
These features enable full CRUD (create, read, update, delete) support, ensuring the application can update and remove student data as needed for real-world usage.

