### PR TITLE
Replace Custom DAO with Spring Data JPA

### DIFF
--- a/04-spring-boot-rest-crud/02-spring-boot-rest-crud-employee/src/main/java/np/com/krishnabk/employeecrud/rest/EmployeeRestController.java
+++ b/04-spring-boot-rest-crud/02-spring-boot-rest-crud-employee/src/main/java/np/com/krishnabk/employeecrud/rest/EmployeeRestController.java
@@ -105,4 +105,22 @@ public class EmployeeRestController {
 
         return objectMapper.convertValue(employeeNode, Employee.class);
     }
+
+    // add mapping for DELETE /employees/{employeeId} - delete employee
+    @DeleteMapping("/employees/{employeeId}")
+    public String deleteEmployee (@PathVariable int employeeId){
+
+        // find employee by id
+        Employee tempEmployee = employeeService.findById(employeeId);
+
+        // throw exception if not exist
+        if (tempEmployee == null){
+            throw new RuntimeException("Employee id not found - " + employeeId);
+        }
+
+        // delete employee
+        employeeService.deleteById(employeeId);
+
+        return "Deleted employee id " + employeeId;
+    }
 }

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/.gitattributes
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/.gitignore
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/pom.xml
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.3</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>np.com.krishna-bk</groupId>
+    <artifactId>employeecrud</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>02-spring-boot-rest-crud-employee</name>
+    <description>02-spring-boot-rest-crud-employee</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/Application.java
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/Application.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.employeecrud;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/dao/EmployeeRepository.java
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/dao/EmployeeRepository.java
@@ -1,0 +1,8 @@
+package np.com.krishnabk.employeecrud.dao;
+
+import np.com.krishnabk.employeecrud.entity.Employee;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployeeRepository extends JpaRepository<Employee, Integer> {
+    // that's it ... no need to write any code LOL!
+}

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/entity/Employee.java
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/entity/Employee.java
@@ -1,0 +1,83 @@
+package np.com.krishnabk.employeecrud.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "employee")
+public class Employee {
+
+    // define fields
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
+
+    @Column(name = "email")
+    private String email;
+
+
+    // define constructors
+
+    public Employee() {
+    }
+
+    public Employee(String firstName, String lastName, String email) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+    }
+
+    // define getters/ setters
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+
+    // define toString
+
+    @Override
+    public String toString() {
+        return "Employee{" +
+                "id=" + id +
+                ", firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", email='" + email + '\'' +
+                '}';
+    }
+}

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/rest/EmployeeRestController.java
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/rest/EmployeeRestController.java
@@ -1,0 +1,126 @@
+package np.com.krishnabk.employeecrud.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import np.com.krishnabk.employeecrud.entity.Employee;
+import np.com.krishnabk.employeecrud.service.EmployeeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/")
+public class EmployeeRestController {
+
+    private EmployeeService employeeService;
+
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    public EmployeeRestController(EmployeeService theEmployeeService, ObjectMapper theObjectMapper){
+        employeeService = theEmployeeService;
+        objectMapper = theObjectMapper;
+    }
+
+    // expose "/employees" and return a list of employees
+    @GetMapping("/employees")
+    public List<Employee> findAll(){
+        return employeeService.findAll();
+    }
+
+    // add mapping for GET /employees/{employeeId}
+    @GetMapping("/employees/{employeeId}")
+    public Employee getEmployee(@PathVariable int employeeId){
+
+        Employee theEmployee = employeeService.findById(employeeId);
+
+        if (theEmployee == null){
+            throw new RuntimeException("Employee id not found - " + theEmployee);
+        }
+
+        return theEmployee;
+    }
+
+    // add mapping for POST /employees - add new employee
+    @PostMapping("/employees")
+    public Employee addEmployee(@RequestBody Employee theEmployee){
+
+        // also just in case they pass an id in JSON ... set id to 0
+        // this is to force a save of new item ... instead of update
+
+        theEmployee.setId(0);
+
+        Employee dbEmployee = employeeService.save(theEmployee);
+
+        return theEmployee;
+    }
+
+
+    // add mapping for PUT /employees - update existing employee
+    @PutMapping("/employees")
+    public Employee updateEmployee(@RequestBody Employee theEmployee){
+
+        Employee dbEmployee = employeeService.save(theEmployee);
+
+        return dbEmployee;
+    }
+
+    // add mapping for PATCH /employees/{employeeId} - patch employee ... partial update
+
+    @PatchMapping("/employees/{employeeId}")
+    public Employee patchEmployee(@PathVariable int employeeId,
+                                  @RequestBody Map<String, Object> patchPayload) {
+
+        Employee tempEmployee = employeeService.findById(employeeId);
+
+        // throw exception if null
+        if (tempEmployee == null) {
+            throw new RuntimeException("Employee id not found - " + employeeId);
+        }
+
+        // throw exception if request body contains "id" key
+        if (patchPayload.containsKey("id")) {
+            throw new RuntimeException("Employee id not allowed in request body - " + employeeId);
+        }
+
+        Employee patchedEmployee = apply(patchPayload, tempEmployee);
+
+        Employee dbEmployee = employeeService.save(patchedEmployee);
+
+        return dbEmployee;
+    }
+
+    private Employee apply(Map<String, Object> patchPayload, Employee tempEmployee) {
+
+        // Convert employee object to a JSON object node
+        ObjectNode employeeNode = objectMapper.convertValue(tempEmployee, ObjectNode.class);
+
+        // Convert the patchPayload map to a JSON object node
+        ObjectNode patchNode = objectMapper.convertValue(patchPayload, ObjectNode.class);
+
+        // Merge the patch updates into the employee node
+        employeeNode.setAll(patchNode);
+
+        return objectMapper.convertValue(employeeNode, Employee.class);
+    }
+
+    // add mapping for DELETE /employees/{employeeId} - delete employee
+    @DeleteMapping("/employees/{employeeId}")
+    public String deleteEmployee (@PathVariable int employeeId){
+
+        // find employee by id
+        Employee tempEmployee = employeeService.findById(employeeId);
+
+        // throw exception if not exist
+        if (tempEmployee == null){
+            throw new RuntimeException("Employee id not found - " + employeeId);
+        }
+
+        // delete employee
+        employeeService.deleteById(employeeId);
+
+        return "Deleted employee id " + employeeId;
+    }
+}

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/service/EmployeeService.java
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/service/EmployeeService.java
@@ -1,0 +1,16 @@
+package np.com.krishnabk.employeecrud.service;
+
+import np.com.krishnabk.employeecrud.entity.Employee;
+
+import java.util.List;
+
+public interface EmployeeService {
+
+    List<Employee> findAll();
+
+    Employee findById(int theId);
+
+    Employee save(Employee theEmployee);
+
+    void deleteById(int theId);
+}

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/service/EmployeeServiceImpl.java
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/service/EmployeeServiceImpl.java
@@ -1,44 +1,55 @@
 package np.com.krishnabk.employeecrud.service;
 
+import np.com.krishnabk.employeecrud.dao.EmployeeRepository;
 import np.com.krishnabk.employeecrud.entity.Employee;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class EmployeeServiceImpl implements EmployeeService {
 
     // define field
-    private EmployeeDAO employeeDAO;
+    private EmployeeRepository employeeRepository;
 
     // constructor injection
     @Autowired
-    public EmployeeServiceImpl(EmployeeDAO theEmployeeDAO){
-        employeeDAO = theEmployeeDAO;
+    public EmployeeServiceImpl(EmployeeRepository theEmployeeRepository){
+        employeeRepository = theEmployeeRepository;
     }
 
 
     @Override
     public List<Employee> findAll() {
-        return employeeDAO.findAll();
+        return employeeRepository.findAll();
     }
 
     @Override
     public Employee findById(int theId) {
-        return employeeDAO.findById(theId);
+        Optional<Employee> result = employeeRepository.findById(theId);
+
+        Employee theEmployee = null;
+
+        if(result.isPresent()){
+            theEmployee = result.get();
+        } else {
+            // we didn't find the employee
+            throw new RuntimeException("Did not find employee id - " + theId);
+        }
+
+        return theEmployee;
     }
 
-    @Transactional
     @Override
     public Employee save(Employee theEmployee) {
-        return employeeDAO.save(theEmployee);
+        return employeeRepository.save(theEmployee);
     }
 
-    @Transactional
     @Override
     public void deleteById(int theId) {
-        employeeDAO.deleteById(theId);
+        employeeRepository.deleteById(theId);
     }
 }

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/service/EmployeeServiceImpl.java
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/java/np/com/krishnabk/employeecrud/service/EmployeeServiceImpl.java
@@ -1,0 +1,44 @@
+package np.com.krishnabk.employeecrud.service;
+
+import np.com.krishnabk.employeecrud.entity.Employee;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class EmployeeServiceImpl implements EmployeeService {
+
+    // define field
+    private EmployeeDAO employeeDAO;
+
+    // constructor injection
+    @Autowired
+    public EmployeeServiceImpl(EmployeeDAO theEmployeeDAO){
+        employeeDAO = theEmployeeDAO;
+    }
+
+
+    @Override
+    public List<Employee> findAll() {
+        return employeeDAO.findAll();
+    }
+
+    @Override
+    public Employee findById(int theId) {
+        return employeeDAO.findById(theId);
+    }
+
+    @Transactional
+    @Override
+    public Employee save(Employee theEmployee) {
+        return employeeDAO.save(theEmployee);
+    }
+
+    @Transactional
+    @Override
+    public void deleteById(int theId) {
+        employeeDAO.deleteById(theId);
+    }
+}

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/resources/application.properties
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.application.name=02-spring-boot-rest-crud-employee
+
+# JDBC properties
+spring.datasource.url=jdbc:mysql://localhost:3306/employee_directory
+spring.datasource.username=springstudent
+spring.datasource.password=springstudent

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/resources/employee-directory.sql
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/main/resources/employee-directory.sql
@@ -1,0 +1,28 @@
+CREATE DATABASE  IF NOT EXISTS `employee_directory`;
+USE `employee_directory`;
+
+--
+-- Table structure for table `employee`
+--
+
+DROP TABLE IF EXISTS `employee`;
+
+CREATE TABLE `employee` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+--
+-- Data for table `employee`
+--
+
+INSERT INTO `employee` VALUES 
+	(1,'Leslie','Andrews','leslie@luv2code.com'),
+	(2,'Emma','Baumgarten','emma@luv2code.com'),
+	(3,'Avani','Gupta','avani@luv2code.com'),
+	(4,'Yuri','Petrov','yuri@luv2code.com'),
+	(5,'Juan','Vega','juan@luv2code.com');
+

--- a/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/test/java/np/com/krishnabk/employeecrud/ApplicationTests.java
+++ b/04-spring-boot-rest-crud/03-spring-boot-rest-crud-employee-with-spring-data-jpa/src/test/java/np/com/krishnabk/employeecrud/ApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.employeecrud;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
This PR replaces the manually implemented `EmployeeDAO` with a more concise and maintainable `EmployeeRepository` using Spring Data JPA.

**Changes Introduced**

* Introduced `EmployeeRepository` extending `JpaRepository<Employee, Integer>`
* Refactored `EmployeeServiceImpl` to use `EmployeeRepository` instead of `EmployeeDAO`
* Removed unnecessary `@Transactional` annotations (now managed by Spring Data JPA)
* Preserved existing logic for CRUD operations with improved readability and reduced boilerplate

**Benefits**

* Reduces boilerplate code
* Leverages Spring Data JPA's powerful abstractions
* Improves maintainability and readability of service layer

**Tested**

* ✅ `GET /employees`
* ✅ `GET /employees/{id}`
* ✅ `POST /employees`
* ✅ `PUT /employees`
* ✅ `DELETE /employees/{id}`

---

