### PR TITLE
feat(view): render favorite programming languages dynamically from properties

### DIFF
--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/controller/StudentController.java
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/controller/StudentController.java
@@ -45,7 +45,7 @@ public class StudentController {
 
         System.out.println("country: " + theStudent.getCountry());
 
-        System.out.println("favProgrammingLanguage " + theStudent.getFavoriteLanguage());
+        System.out.println("favProgrammingLanguage: " + theStudent.getFavoriteLanguage());
 
         return "student-confirmation";
     }

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/controller/StudentController.java
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/controller/StudentController.java
@@ -13,6 +13,9 @@ import java.util.List;
 @Controller
 public class StudentController {
 
+    @Value("${languages}")
+    private List<String> languages;
+
     @Value("${countries}")
     private List<String> countries;
 
@@ -25,8 +28,11 @@ public class StudentController {
         // add student object to the model
         theModel.addAttribute("student", theStudent);
 
-        // add list of countries to the model
+        // add the list of countries to the model
         theModel.addAttribute("countries", countries);
+
+        // add the list of languages to the model
+        theModel.addAttribute("languages", languages);
 
         return "student-form";
     }
@@ -36,6 +42,10 @@ public class StudentController {
 
         // log the input data
         System.out.println("theStudent: " + theStudent.getFirstName() + " " + theStudent.getLastName());
+
+        System.out.println("country: " + theStudent.getCountry());
+
+        System.out.println("favProgrammingLanguage " + theStudent.getFavoriteLanguage());
 
         return "student-confirmation";
     }

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/model/Student.java
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/model/Student.java
@@ -5,6 +5,7 @@ public class Student {
     private String firstName;
     private String lastName;
     private String country;
+    private String favoriteLanguage;
 
     public Student(){}
 
@@ -30,5 +31,13 @@ public class Student {
 
     public void setCountry(String country) {
         this.country = country;
+    }
+
+    public String getFavoriteLanguage() {
+        return favoriteLanguage;
+    }
+
+    public void setFavoriteLanguage(String favoriteLanguage) {
+        this.favoriteLanguage = favoriteLanguage;
     }
 }

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/application.properties
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 spring.application.name=01-thymeleafdemo-helloworld
 
 countries=Nepal, China, Bhutan, Indonesia, Brazil, Germany, Spain, Mexico, United Stat, Australia
+
+languages=Java, Go, Python, C++, JavaScript, Rust, TypeScript

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-confirmation.html
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-confirmation.html
@@ -17,7 +17,7 @@ Country: <span th:text="${student.country}"></span>
 
 <br><br>
 
-Favourite Programming Language: <span th:text="${student.favoriteLanguage}"></span>
+Favorite Programming Language: <span th:text="${student.favoriteLanguage}"></span>
 
 </body>
 </html>

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-confirmation.html
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-confirmation.html
@@ -9,12 +9,15 @@
 
 <h3>Student Confirmation</h3>
 
-The student is confirmed:
-    <span th:text="${student.firstName + ' ' + student.lastName}"></span>
+The student is confirmed: <span th:text="${student.firstName + ' ' + student.lastName}"></span>
 
-    <br><br>
+<br><br>
 
-    Country: <span th:text="${student.country}"></span>
+Country: <span th:text="${student.country}"></span>
+
+<br><br>
+
+Favourite Programming Language: <span th:text="${student.favoriteLanguage}"></span>
 
 </body>
 </html>

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
@@ -29,6 +29,24 @@
 
     <br><br>
 
+    Favourite Programming Language:
+
+    <label>
+        <input type="radio" th:field="*{favoriteLanguage}" th:value="Go"> Go
+    </label>
+    <label>
+        <input type="radio" th:field="*{favoriteLanguage}" th:value="Java"> Java
+    </label>
+    <label>
+        <input type="radio" th:field="*{favoriteLanguage}" th:value="Python"> Python
+    </label>
+    <label>
+        <input type="radio" th:field="*{favoriteLanguage}" th:value="CPP"> CPP
+    </label>
+
+
+    <br><br>
+
     <input type="submit" value="Submit">
 
 </form>

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
@@ -29,7 +29,7 @@
 
     <br><br>
 
-    Favourite Programming Language:
+    Favorite Programming Language:
 
     <input type="radio" th:field="*{favoriteLanguage}"
                             th:each="tempLang : ${languages}"

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
@@ -31,18 +31,11 @@
 
     Favourite Programming Language:
 
-    <label>
-        <input type="radio" th:field="*{favoriteLanguage}" th:value="Go"> Go
-    </label>
-    <label>
-        <input type="radio" th:field="*{favoriteLanguage}" th:value="Java"> Java
-    </label>
-    <label>
-        <input type="radio" th:field="*{favoriteLanguage}" th:value="Python"> Python
-    </label>
-    <label>
-        <input type="radio" th:field="*{favoriteLanguage}" th:value="CPP"> CPP
-    </label>
+    <input type="radio" th:field="*{favoriteLanguage}"
+                            th:each="tempLang : ${languages}"
+                            th:value="${tempLang}"
+                            th:text="${tempLang}"
+    />
 
 
     <br><br>


### PR DESCRIPTION
This PR updates the student form to render favorite programming language options dynamically from application properties.

Changes:
- Added property in application.properties to store language list.
- Updated Thymeleaf template to iterate over the list instead of hardcoding values.
- Ensured form binding works with new dynamic values.
