### PR TITLE
feat(view): add and populate favorite operating systems dynamically

### DIFF
--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/controller/StudentController.java
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/controller/StudentController.java
@@ -13,6 +13,9 @@ import java.util.List;
 @Controller
 public class StudentController {
 
+    @Value("${systems}")
+    private List<String> systems;
+
     @Value("${languages}")
     private List<String> languages;
 
@@ -33,6 +36,9 @@ public class StudentController {
 
         // add the list of languages to the model
         theModel.addAttribute("languages", languages);
+
+        // add the list of operating systems to the model
+        theModel.addAttribute("systems", systems);
 
         return "student-form";
     }

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/controller/StudentController.java
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/controller/StudentController.java
@@ -45,7 +45,9 @@ public class StudentController {
 
         System.out.println("country: " + theStudent.getCountry());
 
-        System.out.println("favProgrammingLanguage " + theStudent.getFavoriteLanguage());
+        System.out.println("favProgrammingLanguage: " + theStudent.getFavoriteLanguage());
+
+        System.out.println("favSystem: " + theStudent.getFavoriteSystems());
 
         return "student-confirmation";
     }

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/model/Student.java
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/java/np/com/krishnabk/thymeleafdemo/model/Student.java
@@ -1,11 +1,14 @@
 package np.com.krishnabk.thymeleafdemo.model;
 
+import java.util.List;
+
 public class Student {
 
     private String firstName;
     private String lastName;
     private String country;
     private String favoriteLanguage;
+    private List<String> favoriteSystems;
 
     public Student(){}
 
@@ -39,5 +42,13 @@ public class Student {
 
     public void setFavoriteLanguage(String favoriteLanguage) {
         this.favoriteLanguage = favoriteLanguage;
+    }
+
+    public List<String> getFavoriteSystems() {
+        return favoriteSystems;
+    }
+
+    public void setFavoriteSystems(List<String> favoriteSystems) {
+        this.favoriteSystems = favoriteSystems;
     }
 }

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/application.properties
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/application.properties
@@ -4,4 +4,4 @@ countries=Nepal, China, Bhutan, Indonesia, Brazil, Germany, Spain, Mexico, Unite
 
 languages=Java, Go, Python, C++, JavaScript, Rust, TypeScript
 
-systems=macOS, Linux, Microsoft Windows
+systems=macOS, Linux, Microsoft Windows, Android, iOS

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/application.properties
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/application.properties
@@ -3,3 +3,5 @@ spring.application.name=01-thymeleafdemo-helloworld
 countries=Nepal, China, Bhutan, Indonesia, Brazil, Germany, Spain, Mexico, United Stat, Australia
 
 languages=Java, Go, Python, C++, JavaScript, Rust, TypeScript
+
+systems=macOS, Linux, Microsoft Windows

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-confirmation.html
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-confirmation.html
@@ -19,5 +19,13 @@ Country: <span th:text="${student.country}"></span>
 
 Favourite Programming Language: <span th:text="${student.favoriteLanguage}"></span>
 
+<br><br>
+
+Favourite Operating Systems:
+
+<ul>
+    <li th:each="tempSystem : ${student.favoriteSystems}" th:text="${tempSystem}"></li>
+</ul>
+
 </body>
 </html>

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
@@ -37,6 +37,13 @@
                             th:text="${tempLang}"
     />
 
+    <br><br>
+
+    Favourite Operating Systems:
+
+    <input type="checkbox" th:field="*{favoriteSystems}" th:value="Linux">Linux
+    <input type="checkbox" th:field="*{favoriteSystems}" th:value="macOS">macOS
+    <input type="checkbox" th:field="*{favoriteSystems}" th:value="'Microsoft Windows'">Microsoft Windows
 
     <br><br>
 

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
@@ -32,18 +32,20 @@
     Favourite Programming Language:
 
     <input type="radio" th:field="*{favoriteLanguage}"
-                            th:each="tempLang : ${languages}"
-                            th:value="${tempLang}"
-                            th:text="${tempLang}"
-    />
+                        th:each="tempLang : ${languages}"
+                        th:value="${tempLang}"
+                        th:text="${tempLang}"
+            />
 
     <br><br>
 
     Favourite Operating Systems:
+    <input type="checkbox" th:field="*{favoriteSystems}"
+                            th:each="tempSystem : ${systems}"
+                            th:value="${tempSystem}"
+                            th:text="${tempSystem}"
+           />
 
-    <input type="checkbox" th:field="*{favoriteSystems}" th:value="Linux">Linux
-    <input type="checkbox" th:field="*{favoriteSystems}" th:value="macOS">macOS
-    <input type="checkbox" th:field="*{favoriteSystems}" th:value="'Microsoft Windows'">Microsoft Windows
 
     <br><br>
 

--- a/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
+++ b/06-spring-boot-spring-mvc/01-thymeleafdemo-helloworld/src/main/resources/templates/student-form.html
@@ -41,9 +41,9 @@
 
     Favourite Operating Systems:
     <input type="checkbox" th:field="*{favoriteSystems}"
-                            th:each="tempSystem : ${systems}"
-                            th:value="${tempSystem}"
-                            th:text="${tempSystem}"
+                           th:each="tempSystem : ${systems}"
+                           th:value="${tempSystem}"
+                           th:text="${tempSystem}"
            />
 
 


### PR DESCRIPTION
### Summary
This PR enhances the student form by adding support for selecting favorite operating systems, with values loaded dynamically from application properties.

### Changes
- Added `favoriteOperatingSystems` property to the Student model.
- Updated `student-form.html` to include checkboxes for favorite operating systems.
- Populated checkbox options dynamically from application properties using Thymeleaf iteration.
- Added display of selected operating systems in `student-confirmation.html`.
- Extended application properties to include additional OS options.
- Refined naming for improved code clarity and consistency.

### Motivation
Previously, operating system options were not part of the form. This change improves flexibility by loading the list from configuration, making it easy to update without modifying templates.
