### PR TITLE
Add validation for `freePasses` with custom error messages

### DIFF
--- a/06-spring-boot-spring-mvc/02-springmvc-validationdemo/src/main/java/np/com/krishnabk/springdemo/mvc/Customer.java
+++ b/06-spring-boot-spring-mvc/02-springmvc-validationdemo/src/main/java/np/com/krishnabk/springdemo/mvc/Customer.java
@@ -4,9 +4,10 @@ import jakarta.validation.constraints.*;
 
 public class Customer {
 
+    @NotNull(message = "is required")
     @Min(value = 0, message = "must be greater than or equal to zero")
     @Max(value = 10, message = "must be less than or equal to 10")
-    private int freePasses;
+    private Integer freePasses;
 
     @Pattern(regexp = "^[a-zA-Z0-9]{5}", message = "only 5 chars/digits")
     private String postalCode;
@@ -33,11 +34,11 @@ public class Customer {
         this.lastName = lastName;
     }
 
-    public int getFreePasses() {
+    public Integer getFreePasses() {
         return freePasses;
     }
 
-    public void setFreePasses(int freePasses) {
+    public void setFreePasses(Integer freePasses) {
         this.freePasses = freePasses;
     }
 

--- a/06-spring-boot-spring-mvc/02-springmvc-validationdemo/src/main/java/np/com/krishnabk/springdemo/mvc/CustomerController.java
+++ b/06-spring-boot-spring-mvc/02-springmvc-validationdemo/src/main/java/np/com/krishnabk/springdemo/mvc/CustomerController.java
@@ -39,6 +39,9 @@ public class CustomerController {
             BindingResult theBindingResult){
 
         System.out.println("Last name: |" + theCustomer.getLastName() + "|");
+
+        System.out.println("Binding results: " + theBindingResult.toString());
+
         if(theBindingResult.hasErrors()){
             return "customer-form";
         }

--- a/06-spring-boot-spring-mvc/02-springmvc-validationdemo/src/main/resources/messages.properties
+++ b/06-spring-boot-spring-mvc/02-springmvc-validationdemo/src/main/resources/messages.properties
@@ -1,0 +1,1 @@
+typeMismatch.customer.freePasses=Invalid Number

--- a/06-spring-boot-spring-mvc/02-springmvc-validationdemo/src/main/resources/templates/customer-form.html
+++ b/06-spring-boot-spring-mvc/02-springmvc-validationdemo/src/main/resources/templates/customer-form.html
@@ -31,7 +31,7 @@
 
     <br><br>
 
-    Free Passes: <input type="text" th:field="*{freePasses}">
+    Free Passes (*): <input type="text" th:field="*{freePasses}">
 
     <!-- Add error message (if present) -->
     <span th:if="${#fields.hasErrors('freePasses')}"


### PR DESCRIPTION
### Changes
- Made `freePasses` required using `@NotNull` validation.
- Updated `customer-form.html` label to indicate required field.
- Added custom error message for type mismatch (`Invalid Number`).
- Added temporary debug logs for BindingResult (to be replaced with proper logger).
