### PR TITLE
feat: implement role-based access, leadership/admin pages, and UI enhancements

### DIFF
--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/DemoController.java
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/DemoController.java
@@ -7,8 +7,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class DemoController {
 
     @GetMapping("/")
-    public String showForm(){
+    public String showForm() {
 
         return "home";
+    }
+
+    @GetMapping("/leaders")
+    public String showLeaders() {
+
+        return "leaders";
     }
 }

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/DemoController.java
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/DemoController.java
@@ -17,4 +17,11 @@ public class DemoController {
 
         return "leaders";
     }
+
+    // add mapping for /systems
+    @GetMapping("/systems")
+    public String showSystems() {
+
+        return "systems";
+    }
 }

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
@@ -40,6 +40,9 @@ public class DemoSecurityConfig {
 
         http.authorizeHttpRequests(configurer ->
                         configurer
+                                .requestMatchers("/").hasRole("EMPLOYEE")
+                                .requestMatchers("/leaders/**").hasRole("MANAGER")
+                                .requestMatchers("/systems/**").hasRole("ADMIN")
                                 .anyRequest().authenticated()
                 )
                 .formLogin(form ->

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/fancy-login.html
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/fancy-login.html
@@ -8,7 +8,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 100vh;
+            width: 100vw;
             margin-top: 50px;
             padding: 0;
         }

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/fancy-login.html
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/fancy-login.html
@@ -8,7 +8,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 100vw;
+            width: 100vh;
             margin-top: 50px;
             padding: 0;
         }

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/fancy-login.html
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/fancy-login.html
@@ -3,11 +3,21 @@
 <head>
     <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css"
           integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" rel="stylesheet"/>
+    <style>
+        #loginbox {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100vh;
+            margin-top: 50px;
+            padding: 0;
+        }
+    </style>
 </head>
 
 <body>
 <div class="container">
-    <div class="col-md-3 col-md-offset-2 col-sm-6 col-sm-offset-2" id="loginbox" style="margin-top: 50px;">
+    <div class="col-md-3 col-md-offset-2 col-sm-6 col-sm-offset-2" id="loginbox">
         <div class="card border-info">
             <div class="card-header bg-info">
                 Sign In

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/home.html
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/home.html
@@ -36,8 +36,15 @@
 <!-- Add a link to point to /leader ... this is for the managers -->
 <p>
     <a th:href="@{/leaders}">Leadership Meeting</a>
-    (Only for Manager peps)
+    (Only for Manager peeps)
 </p>
+
+<!-- Add a link to point to /systems ... this is only for admins-->
+<p>
+    <a th:href="@{/systems}">IT Systems Meeting</a>
+    (Only for Admin peeps)
+</p>
+
 <hr>
 <!-- Add a logout button-->
 <form action="#" method="POST" th:action="@{/logout}">

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/home.html
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/home.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>KrishnaKompany Home Page</title>
@@ -22,6 +23,16 @@
 
 <p>Welcome to the KrishnaKompany home page!</p>
 
+<hr>
+
+<!-- Display user name and role -->
+<p>
+    User: <span sec:authentication="principal.username"></span>
+    <br><br>
+    Role: <span sec:authentication="principal.authorities"></span>
+</p>
+
+<hr>
 <!-- Add a logout button-->
 <form action="#" method="POST" th:action="@{/logout}">
     <input type="submit" value="Log Out">

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/home.html
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/home.html
@@ -33,6 +33,12 @@
 </p>
 
 <hr>
+<!-- Add a link to point to /leader ... this is for the managers -->
+<p>
+    <a th:href="@{/leaders}">Leadership Meeting</a>
+    (Only for Manager peps)
+</p>
+<hr>
 <!-- Add a logout button-->
 <form action="#" method="POST" th:action="@{/logout}">
     <input type="submit" value="Log Out">

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/leaders.html
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/leaders.html
@@ -13,7 +13,7 @@
 <p>
     See you in Indonesia ... for our annual leadership retreat!
     <br>
-    Keep this trip a secret, don't tell the regular employee LOL :-)
+    Keep this trip a secret, don't tell the regular employees LOL :-)
 </p>
 
 <hr>

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/leaders.html
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/leaders.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>KrishnaKompany LEADERS Home Page</title>
+</head>
+<body>
+
+<h2>KrishnaKompany LEADERS Home Page</h2>
+
+<hr>
+
+<p>
+    See you in Indonesia ... for our annual leadership retreat!
+    <br>
+    Keep this trip a secret, don't tell the regular employee LOL :-)
+</p>
+
+<hr>
+
+<a th:href="@{/}">Back to home page</a>
+
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/systems.html
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/systems.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>KrishnaKompany SYSTEMS Home Page</title>
+</head>
+<body>
+<h2>KrishnaKompany SYSTEMS Home Page</h2>
+<hr>
+
+<p>
+    We have annual holiday Caribbean cruise coming up. Register now!
+    <br>
+    Keep this trip a secret, don't tell the regular employees LOL :-)
+</p>
+
+<hr>
+<a th:href="@{/}">Back to Home Page</a>
+</body>
+</html>


### PR DESCRIPTION
## Overview

This pull request introduces a comprehensive set of features and improvements to the security, controller logic, and UI for the Spring Boot MVC Security Demo project.

### Key Changes

#### 1. Role-Based Access Control
- Configured role-based restrictions in `DemoSecurityConfig`:
  - Only users with the EMPLOYEE role can access the root (`/`).
  - Only MANAGERs can access `/leaders/**`.
  - Only ADMINs can access `/systems/**`.

#### 2. New Endpoints and Pages
- Added `/leaders` endpoint and corresponding `leaders.html` page for managers.
- Added `/systems` endpoint and corresponding `systems.html` page for admins.
- Both new pages display exclusive content and provide navigation back to the home page.

#### 3. UI Improvements
- Login form is now centered in `fancy-login.html` for a more polished appearance.
- Home page displays the authenticated user's name and roles using Thymeleaf Spring Security extras.
- Conditional navigation links:
  - Leadership meeting link for MANAGERs (`/leaders`)
  - IT systems meeting link for ADMINs (`/systems`)

#### 4. Code and Template Enhancements
- Refactored controller to include new endpoints for `/leaders` and `/systems`.
- Added clear comments and improved HTML for maintainability.

---

## How to Test

1. Log in with users having different roles (EMPLOYEE, MANAGER, ADMIN).
2. Verify that only authorized users can access `/`, `/leaders`, and `/systems`.
3. Confirm correct display and layout of login and home pages.
4. Ensure exclusive content is visible only to users with the appropriate roles.