### PR TITLE
feat(ui): show user info and links conditionally by role on home page

### DIFF
--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/home.html
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/templates/home.html
@@ -25,25 +25,31 @@
 
 <hr>
 
-<!-- Display user name and role -->
-<p>
-    User: <span sec:authentication="principal.username"></span>
-    <br><br>
-    Role: <span sec:authentication="principal.authorities"></span>
-</p>
+<div sec:authorize="hasRole('EMPLOYEE')">
+    <!-- Display user name and role -->
+    <p>
+        User: <span sec:authentication="principal.username"></span>
+        <br><br>
+        Role: <span sec:authentication="principal.authorities"></span>
+    </p>
+</div>
 
-<hr>
-<!-- Add a link to point to /leader ... this is for the managers -->
-<p>
-    <a th:href="@{/leaders}">Leadership Meeting</a>
-    (Only for Manager peeps)
-</p>
+<div sec:authorize="hasRole('MANAGER')">
+    <!-- Add a link to point to /leader ... this is for the managers -->
+    <hr>
+    <p>
+        <a th:href="@{/leaders}">Leadership Meeting</a>
+        (Only for Manager peeps)
+    </p>
+</div>
 
-<!-- Add a link to point to /systems ... this is only for admins-->
-<p>
-    <a th:href="@{/systems}">IT Systems Meeting</a>
-    (Only for Admin peeps)
-</p>
+<div sec:authorize="hasRole('ADMIN')">
+    <!-- Add a link to point to /systems ... this is only for admins-->
+    <p>
+        <a th:href="@{/systems}">IT Systems Meeting</a>
+        (Only for Admin peeps)
+    </p>
+</div>
 
 <hr>
 <!-- Add a logout button-->


### PR DESCRIPTION
- Wrapped user info and navigation links in Thymeleaf `sec:authorize` blocks
- User details now only display for `EMPLOYEE` role
- Leadership meeting link only visible to `MANAGER` role
- IT systems meeting link only visible to `ADMIN` role