### PR TITLE
feat: integrate MySQL database, JPA, and JDBC-based user authentication

### DIFF
--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/pom.xml
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -30,6 +30,15 @@
         <java.version>17</java.version>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/sql-scripts/04-setup-spring-security-demo-database-plaintext.sql
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/sql-scripts/04-setup-spring-security-demo-database-plaintext.sql
@@ -1,0 +1,54 @@
+USE `employee_directory`;
+
+DROP TABLE IF EXISTS `authorities`;
+DROP TABLE IF EXISTS `users`;
+
+--
+-- Table structure for table `users`
+--
+
+CREATE TABLE `users`
+(
+    `username` varchar(50) NOT NULL,
+    `password` varchar(50) NOT NULL,
+    `enabled`  tinyint     NOT NULL,
+    PRIMARY KEY (`username`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+--
+-- Inserting data for table `users`
+--
+
+INSERT INTO `users`
+VALUES ('john', '{noop}test123', 1),
+       ('mary', '{noop}test123', 1),
+       ('riya', '{noop}test123', 1);
+
+
+--
+-- Table structure for table `authorities`
+--
+
+CREATE TABLE `authorities`
+(
+    `username`  varchar(50) NOT NULL,
+    `authority` varchar(50) NOT NULL,
+    UNIQUE KEY `authorities_idx_1` (`username`, `authority`),
+    CONSTRAINT `authorities_ibfk_1` FOREIGN KEY (`username`) REFERENCES `users` (`username`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+--
+-- Inserting data for table `authorities`
+--
+
+INSERT INTO `authorities`
+VALUES ('john', 'ROLE_EMPLOYEE'),
+       ('mary', 'ROLE_EMPLOYEE'),
+       ('mary', 'ROLE_MANAGER'),
+       ('riya', 'ROLE_EMPLOYEE'),
+       ('riya', 'ROLE_MANAGER'),
+       ('riya', 'ROLE_ADMIN');
+
+

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/sql-scripts/05-setup-spring-security-demo-database-bcrypt.sql
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/sql-scripts/05-setup-spring-security-demo-database-bcrypt.sql
@@ -1,0 +1,56 @@
+USE `employee_directory`;
+
+DROP TABLE IF EXISTS `authorities`;
+DROP TABLE IF EXISTS `users`;
+
+--
+-- Table structure for table `users`
+--
+
+CREATE TABLE `users` (
+  `username` varchar(50) NOT NULL,
+  `password` char(68) NOT NULL,
+  `enabled` tinyint NOT NULL,
+  PRIMARY KEY (`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Inserting data for table `users`
+--
+-- NOTE: The passwords are encrypted using BCrypt
+--
+-- A generation tool is avail at: https://www.luv2code.com/generate-bcrypt-password
+--
+-- Default passwords here are: fun123
+--
+
+INSERT INTO `users` 
+VALUES 
+('john','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1),
+('mary','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1),
+('riya','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1);
+
+
+--
+-- Table structure for table `authorities`
+--
+
+CREATE TABLE `authorities` (
+  `username` varchar(50) NOT NULL,
+  `authority` varchar(50) NOT NULL,
+  UNIQUE KEY `authorities4_idx_1` (`username`,`authority`),
+  CONSTRAINT `authorities4_ibfk_1` FOREIGN KEY (`username`) REFERENCES `users` (`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Inserting data for table `authorities`
+--
+
+INSERT INTO `authorities` 
+VALUES 
+('john','ROLE_EMPLOYEE'),
+('mary','ROLE_EMPLOYEE'),
+('mary','ROLE_MANAGER'),
+('riya','ROLE_EMPLOYEE'),
+('riya','ROLE_MANAGER'),
+('riya','ROLE_ADMIN');

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/sql-scripts/06-setup-spring-security-demo-database-bcrypt-custom-table-names.sql
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/sql-scripts/06-setup-spring-security-demo-database-bcrypt-custom-table-names.sql
@@ -1,0 +1,56 @@
+USE `employee_directory`;
+
+DROP TABLE IF EXISTS `roles`;
+DROP TABLE IF EXISTS `members`;
+
+--
+-- Table structure for table `members`
+--
+
+CREATE TABLE `members` (
+  `user_id` varchar(50) NOT NULL,
+  `pw` char(68) NOT NULL,
+  `active` tinyint NOT NULL,
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Inserting data for table `members`
+--
+-- NOTE: The passwords are encrypted using BCrypt
+--
+-- A generation tool is avail at: https://www.luv2code.com/generate-bcrypt-password
+--
+-- Default passwords here are: fun123
+--
+
+INSERT INTO `members`
+VALUES
+('john','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1),
+('mary','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1),
+('riya','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1);
+
+
+--
+-- Table structure for table `authorities`
+--
+
+CREATE TABLE `roles` (
+  `user_id` varchar(50) NOT NULL,
+  `role` varchar(50) NOT NULL,
+  UNIQUE KEY `authorities5_idx_1` (`user_id`,`role`),
+  CONSTRAINT `authorities5_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `members` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Inserting data for table `roles`
+--
+
+INSERT INTO `roles`
+VALUES
+('john','ROLE_EMPLOYEE'),
+('mary','ROLE_EMPLOYEE'),
+('mary','ROLE_MANAGER'),
+('riya','ROLE_EMPLOYEE'),
+('riya','ROLE_MANAGER'),
+('riya','ROLE_ADMIN');

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/sql-scripts/employee-directory.sql
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/sql-scripts/employee-directory.sql
@@ -1,0 +1,28 @@
+CREATE DATABASE  IF NOT EXISTS `employee_directory`;
+USE `employee_directory`;
+
+--
+-- Table structure for table `employee`
+--
+
+DROP TABLE IF EXISTS `employee`;
+
+CREATE TABLE `employee` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+--
+-- Data for table `employee`
+--
+
+INSERT INTO `employee` VALUES 
+	(1,'Leslie','Andrews','leslie@luv2code.com'),
+	(2,'Emma','Baumgarten','emma@luv2code.com'),
+	(3,'Avani','Gupta','avani@luv2code.com'),
+	(4,'Yuri','Petrov','yuri@luv2code.com'),
+	(5,'Juan','Vega','juan@luv2code.com');
+

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
@@ -3,36 +3,20 @@ package np.com.krishnabk.springboot.demosecurity.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
+import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+
+import javax.sql.DataSource;
 
 @Configuration
 public class DemoSecurityConfig {
 
+    // add support for JDBC ... no more hard coded users
     @Bean
-    public InMemoryUserDetailsManager userDetailsManager() {
+    public UserDetailsManager userDetailsManager(DataSource dataSource) {
 
-        UserDetails john = User.builder()
-                .username("John")
-                .password("{noop}test123")
-                .roles("EMPLOYEE")
-                .build();
-
-        UserDetails mary = User.builder()
-                .username("Mary")
-                .password("{noop}test123")
-                .roles("EMPLOYEE", "MANAGER")
-                .build();
-
-        UserDetails riya = User.builder()
-                .username("Riya")
-                .password("{noop}test123")
-                .roles("EMPLOYEE", "MANAGER", "ADMIN")
-                .build();
-
-        return new InMemoryUserDetailsManager(john, mary, riya);
+        return new JdbcUserDetailsManager(dataSource);
     }
 
     @Bean
@@ -56,5 +40,4 @@ public class DemoSecurityConfig {
                         .accessDeniedPage("/access-denied"));
         return http.build();
     }
-
 }

--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/application.properties
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=demosecurity
+# JDBC Properties
+spring.datasource.url=jdbc:mysql://localhost:3306/employee_directory
+spring.datasource.username=springstudent
+spring.datasource.password=springstudent
+# Log JDBC SQL statements
+#
+# Only use this for dev/testing
+# Don't use for PRODUCTION since it will log usernames
+logging.level.org.springframework.jdbc.core=trace


### PR DESCRIPTION
## Overview

This pull request adds full database integration and configures user authentication to use JDBC and MySQL, moving away from in-memory users.

### Key Changes

- **SQL Scripts:**  
  - Added all necessary SQL script files for database setup and user management.

- **Dependencies:**  
  - Added `mysql-connector-j` and `spring-boot-starter-data-jpa` dependencies in `pom.xml` for database and JPA support.

- **Database Configuration:**  
  - Configured `application.properties` with MySQL datasource settings and enabled SQL logging for development.

- **Security Configuration:**  
  - Switched from `InMemoryUserDetailsManager` to `JdbcUserDetailsManager`.
  - User credentials and roles are now managed in the MySQL database.