### PR TITLE
fix(security): configure JdbcUserDetailsManager with custom queries for user and roles tables

### DIFF
--- a/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
+++ b/08-sprinb-boot-spring-mvc-security/01-spring-boot-spring-mvc-security-default/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
@@ -16,7 +16,17 @@ public class DemoSecurityConfig {
     @Bean
     public UserDetailsManager userDetailsManager(DataSource dataSource) {
 
-        return new JdbcUserDetailsManager(dataSource);
+        JdbcUserDetailsManager jdbcUserDetailsManager = new JdbcUserDetailsManager(dataSource);
+
+        // for user info (must return username, password, enabled)
+        jdbcUserDetailsManager.setUsersByUsernameQuery(
+                "select user_id, pw, active from members where user_id=?");
+
+        // for authorities/roles (must return username, authority)
+        jdbcUserDetailsManager.setAuthoritiesByUsernameQuery(
+                "select user_id, role from roles where user_id=?");
+
+        return jdbcUserDetailsManager;
     }
 
     @Bean


### PR DESCRIPTION
- Set usersByUsernameQuery to select user_id, pw, active from members where user_id=?
- Set authoritiesByUsernameQuery to select user_id, role from roles where user_id=?
- Ensures Spring Security uses the correct schema for authentication and authorization