### PR TITLE
fix(security): configure JdbcUserDetailsManager with custom queries for user and role tables

### DIFF
--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/.gitattributes
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/.gitignore
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/pom.xml
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>np.com.krishnabk.springboot</groupId>
+    <artifactId>demosecurity</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>demosecurity</name>
+    <description>demosecurity</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/01-employee-directory.sql
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/01-employee-directory.sql
@@ -1,0 +1,28 @@
+CREATE DATABASE  IF NOT EXISTS `employee_directory`;
+USE `employee_directory`;
+
+--
+-- Table structure for table `employee`
+--
+
+DROP TABLE IF EXISTS `employee`;
+
+CREATE TABLE `employee` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+--
+-- Data for table `employee`
+--
+
+INSERT INTO `employee` VALUES 
+	(1,'Leslie','Andrews','leslie@luv2code.com'),
+	(2,'Emma','Baumgarten','emma@luv2code.com'),
+	(3,'Avani','Gupta','avani@luv2code.com'),
+	(4,'Yuri','Petrov','yuri@luv2code.com'),
+	(5,'Juan','Vega','juan@luv2code.com');
+

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/02-setup-spring-security-demo-database-hibernate-bcrypt.sql
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/02-setup-spring-security-demo-database-hibernate-bcrypt.sql
@@ -1,0 +1,97 @@
+USE `employee_directory`;
+
+SET foreign_key_checks = 0;
+DROP TABLE IF EXISTS `user`;
+DROP TABLE IF EXISTS `role`;
+SET foreign_key_checks = 1;
+
+--
+-- Table structure for table `user`
+--
+
+DROP TABLE IF EXISTS `user`;
+
+CREATE TABLE `user` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `username` varchar(50) NOT NULL,
+  `password` char(80) NOT NULL,
+  `enabled` tinyint NOT NULL,  
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+--
+-- Dumping data for table `user`
+--
+-- NOTE: The passwords are encrypted using BCrypt
+--
+-- A generation tool is avail at: http://www.luv2code.com/generate-bcrypt-password
+--
+-- Default passwords here are: fun123
+--
+
+INSERT INTO `user` (`username`,`password`,`enabled`)
+VALUES 
+('john','$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K',1),
+('mary','$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K',1),
+('susan','$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K',1);
+
+
+--
+-- Table structure for table `role`
+--
+
+DROP TABLE IF EXISTS `role`;
+
+CREATE TABLE `role` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+--
+-- Dumping data for table `roles`
+--
+
+INSERT INTO `role` (name)
+VALUES 
+('ROLE_EMPLOYEE'),('ROLE_MANAGER'),('ROLE_ADMIN');
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+--
+-- Table structure for table `users_roles`
+--
+
+DROP TABLE IF EXISTS `users_roles`;
+
+CREATE TABLE `users_roles` (
+  `user_id` int NOT NULL,
+  `role_id` int NOT NULL,
+  
+  PRIMARY KEY (`user_id`,`role_id`),
+  
+  KEY `FK_ROLE_idx` (`role_id`),
+  
+  CONSTRAINT `FK_USER_05` FOREIGN KEY (`user_id`) 
+  REFERENCES `user` (`id`) 
+  ON DELETE NO ACTION ON UPDATE NO ACTION,
+  
+  CONSTRAINT `FK_ROLE` FOREIGN KEY (`role_id`) 
+  REFERENCES `role` (`id`) 
+  ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+--
+-- Dumping data for table `users_roles`
+--
+
+INSERT INTO `users_roles` (user_id,role_id)
+VALUES 
+(1, 1),
+(2, 1),
+(2, 2),
+(3, 1),
+(3, 2),
+(3, 3)

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/02-setup-spring-security-demo-database-hibernate-bcrypt.sql
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/02-setup-spring-security-demo-database-hibernate-bcrypt.sql
@@ -11,13 +11,16 @@ SET foreign_key_checks = 1;
 
 DROP TABLE IF EXISTS `user`;
 
-CREATE TABLE `user` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `username` varchar(50) NOT NULL,
-  `password` char(80) NOT NULL,
-  `enabled` tinyint NOT NULL,  
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+CREATE TABLE `user`
+(
+    `id`       int         NOT NULL AUTO_INCREMENT,
+    `username` varchar(50) NOT NULL,
+    `password` char(80)    NOT NULL,
+    `enabled`  tinyint     NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = latin1;
 
 --
 -- Dumping data for table `user`
@@ -29,11 +32,10 @@ CREATE TABLE `user` (
 -- Default passwords here are: fun123
 --
 
-INSERT INTO `user` (`username`,`password`,`enabled`)
-VALUES 
-('john','$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K',1),
-('mary','$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K',1),
-('susan','$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K',1);
+INSERT INTO `user` (`username`, `password`, `enabled`)
+VALUES ('john', '$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K', 1),
+       ('mary', '$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K', 1),
+       ('riya', '$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K', 1);
 
 
 --
@@ -42,19 +44,23 @@ VALUES
 
 DROP TABLE IF EXISTS `role`;
 
-CREATE TABLE `role` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `name` varchar(50) DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+CREATE TABLE `role`
+(
+    `id`   int NOT NULL AUTO_INCREMENT,
+    `name` varchar(50) DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  AUTO_INCREMENT = 1
+  DEFAULT CHARSET = latin1;
 
 --
 -- Dumping data for table `roles`
 --
 
 INSERT INTO `role` (name)
-VALUES 
-('ROLE_EMPLOYEE'),('ROLE_MANAGER'),('ROLE_ADMIN');
+VALUES ('ROLE_EMPLOYEE'),
+       ('ROLE_MANAGER'),
+       ('ROLE_ADMIN');
 
 SET FOREIGN_KEY_CHECKS = 0;
 
@@ -64,22 +70,24 @@ SET FOREIGN_KEY_CHECKS = 0;
 
 DROP TABLE IF EXISTS `users_roles`;
 
-CREATE TABLE `users_roles` (
-  `user_id` int NOT NULL,
-  `role_id` int NOT NULL,
-  
-  PRIMARY KEY (`user_id`,`role_id`),
-  
-  KEY `FK_ROLE_idx` (`role_id`),
-  
-  CONSTRAINT `FK_USER_05` FOREIGN KEY (`user_id`) 
-  REFERENCES `user` (`id`) 
-  ON DELETE NO ACTION ON UPDATE NO ACTION,
-  
-  CONSTRAINT `FK_ROLE` FOREIGN KEY (`role_id`) 
-  REFERENCES `role` (`id`) 
-  ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+CREATE TABLE `users_roles`
+(
+    `user_id` int NOT NULL,
+    `role_id` int NOT NULL,
+
+    PRIMARY KEY (`user_id`, `role_id`),
+
+    KEY `FK_ROLE_idx` (`role_id`),
+
+    CONSTRAINT `FK_USER_05` FOREIGN KEY (`user_id`)
+        REFERENCES `user` (`id`)
+        ON DELETE NO ACTION ON UPDATE NO ACTION,
+
+    CONSTRAINT `FK_ROLE` FOREIGN KEY (`role_id`)
+        REFERENCES `role` (`id`)
+        ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
 
 SET FOREIGN_KEY_CHECKS = 1;
 
@@ -87,11 +95,10 @@ SET FOREIGN_KEY_CHECKS = 1;
 -- Dumping data for table `users_roles`
 --
 
-INSERT INTO `users_roles` (user_id,role_id)
-VALUES 
-(1, 1),
-(2, 1),
-(2, 2),
-(3, 1),
-(3, 2),
-(3, 3)
+INSERT INTO `users_roles` (user_id, role_id)
+VALUES (1, 1),
+       (2, 1),
+       (2, 2),
+       (3, 1),
+       (3, 2),
+       (3, 3)

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/04-setup-spring-security-demo-database-plaintext.sql
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/04-setup-spring-security-demo-database-plaintext.sql
@@ -1,0 +1,54 @@
+USE `employee_directory`;
+
+DROP TABLE IF EXISTS `authorities`;
+DROP TABLE IF EXISTS `users`;
+
+--
+-- Table structure for table `users`
+--
+
+CREATE TABLE `users`
+(
+    `username` varchar(50) NOT NULL,
+    `password` varchar(50) NOT NULL,
+    `enabled`  tinyint     NOT NULL,
+    PRIMARY KEY (`username`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+--
+-- Inserting data for table `users`
+--
+
+INSERT INTO `users`
+VALUES ('john', '{noop}test123', 1),
+       ('mary', '{noop}test123', 1),
+       ('riya', '{noop}test123', 1);
+
+
+--
+-- Table structure for table `authorities`
+--
+
+CREATE TABLE `authorities`
+(
+    `username`  varchar(50) NOT NULL,
+    `authority` varchar(50) NOT NULL,
+    UNIQUE KEY `authorities_idx_1` (`username`, `authority`),
+    CONSTRAINT `authorities_ibfk_1` FOREIGN KEY (`username`) REFERENCES `users` (`username`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = latin1;
+
+--
+-- Inserting data for table `authorities`
+--
+
+INSERT INTO `authorities`
+VALUES ('john', 'ROLE_EMPLOYEE'),
+       ('mary', 'ROLE_EMPLOYEE'),
+       ('mary', 'ROLE_MANAGER'),
+       ('riya', 'ROLE_EMPLOYEE'),
+       ('riya', 'ROLE_MANAGER'),
+       ('riya', 'ROLE_ADMIN');
+
+

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/05-setup-spring-security-demo-database-bcrypt.sql
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/05-setup-spring-security-demo-database-bcrypt.sql
@@ -1,0 +1,56 @@
+USE `employee_directory`;
+
+DROP TABLE IF EXISTS `authorities`;
+DROP TABLE IF EXISTS `users`;
+
+--
+-- Table structure for table `users`
+--
+
+CREATE TABLE `users` (
+  `username` varchar(50) NOT NULL,
+  `password` char(68) NOT NULL,
+  `enabled` tinyint NOT NULL,
+  PRIMARY KEY (`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Inserting data for table `users`
+--
+-- NOTE: The passwords are encrypted using BCrypt
+--
+-- A generation tool is avail at: https://www.luv2code.com/generate-bcrypt-password
+--
+-- Default passwords here are: fun123
+--
+
+INSERT INTO `users` 
+VALUES 
+('john','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1),
+('mary','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1),
+('riya','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1);
+
+
+--
+-- Table structure for table `authorities`
+--
+
+CREATE TABLE `authorities` (
+  `username` varchar(50) NOT NULL,
+  `authority` varchar(50) NOT NULL,
+  UNIQUE KEY `authorities4_idx_1` (`username`,`authority`),
+  CONSTRAINT `authorities4_ibfk_1` FOREIGN KEY (`username`) REFERENCES `users` (`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Inserting data for table `authorities`
+--
+
+INSERT INTO `authorities` 
+VALUES 
+('john','ROLE_EMPLOYEE'),
+('mary','ROLE_EMPLOYEE'),
+('mary','ROLE_MANAGER'),
+('riya','ROLE_EMPLOYEE'),
+('riya','ROLE_MANAGER'),
+('riya','ROLE_ADMIN');

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/06-setup-spring-security-demo-database-bcrypt-custom-table-names.sql
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/06-setup-spring-security-demo-database-bcrypt-custom-table-names.sql
@@ -1,0 +1,56 @@
+USE `employee_directory`;
+
+DROP TABLE IF EXISTS `roles`;
+DROP TABLE IF EXISTS `members`;
+
+--
+-- Table structure for table `members`
+--
+
+CREATE TABLE `members` (
+  `user_id` varchar(50) NOT NULL,
+  `pw` char(68) NOT NULL,
+  `active` tinyint NOT NULL,
+  PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Inserting data for table `members`
+--
+-- NOTE: The passwords are encrypted using BCrypt
+--
+-- A generation tool is avail at: https://www.luv2code.com/generate-bcrypt-password
+--
+-- Default passwords here are: fun123
+--
+
+INSERT INTO `members`
+VALUES
+('john','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1),
+('mary','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1),
+('riya','{bcrypt}$2a$10$qeS0HEh7urweMojsnwNAR.vcXJeXR1UcMRZ2WcGQl9YeuspUdgF.q',1);
+
+
+--
+-- Table structure for table `authorities`
+--
+
+CREATE TABLE `roles` (
+  `user_id` varchar(50) NOT NULL,
+  `role` varchar(50) NOT NULL,
+  UNIQUE KEY `authorities5_idx_1` (`user_id`,`role`),
+  CONSTRAINT `authorities5_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `members` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Inserting data for table `roles`
+--
+
+INSERT INTO `roles`
+VALUES
+('john','ROLE_EMPLOYEE'),
+('mary','ROLE_EMPLOYEE'),
+('mary','ROLE_MANAGER'),
+('riya','ROLE_EMPLOYEE'),
+('riya','ROLE_MANAGER'),
+('riya','ROLE_ADMIN');

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/employee-directory.sql
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/sql-scripts/employee-directory.sql
@@ -1,0 +1,28 @@
+CREATE DATABASE  IF NOT EXISTS `employee_directory`;
+USE `employee_directory`;
+
+--
+-- Table structure for table `employee`
+--
+
+DROP TABLE IF EXISTS `employee`;
+
+CREATE TABLE `employee` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+--
+-- Data for table `employee`
+--
+
+INSERT INTO `employee` VALUES 
+	(1,'Leslie','Andrews','leslie@luv2code.com'),
+	(2,'Emma','Baumgarten','emma@luv2code.com'),
+	(3,'Avani','Gupta','avani@luv2code.com'),
+	(4,'Yuri','Petrov','yuri@luv2code.com'),
+	(5,'Juan','Vega','juan@luv2code.com');
+

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/DemosecurityApplication.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/DemosecurityApplication.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.springboot.demosecurity;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemosecurityApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DemosecurityApplication.class, args);
+    }
+
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/DemoController.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/DemoController.java
@@ -1,0 +1,27 @@
+package np.com.krishnabk.springboot.demosecurity.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class DemoController {
+
+    @GetMapping("/")
+    public String showForm() {
+
+        return "home";
+    }
+
+    @GetMapping("/leaders")
+    public String showLeaders() {
+
+        return "leaders";
+    }
+
+    // add mapping for /systems
+    @GetMapping("/systems")
+    public String showSystems() {
+
+        return "systems";
+    }
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/LoginController.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/LoginController.java
@@ -1,0 +1,22 @@
+package np.com.krishnabk.springboot.demosecurity.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class LoginController {
+
+    @GetMapping("/showMyLoginPage")
+    public String showMyLoginPage() {
+
+        return "fancy-login";
+
+    }
+
+    // add mapping for /access-denied
+    @GetMapping("/access-denied")
+    public String accessDenied() {
+        return "access-denied";
+    }
+
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/dao/RoleDao.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/dao/RoleDao.java
@@ -1,0 +1,9 @@
+package np.com.krishnabk.springboot.demosecurity.dao;
+
+import np.com.krishnabk.springboot.demosecurity.entity.Role;
+
+public interface RoleDao {
+
+    public Role findRoleByName(String theRoleName);
+
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/dao/RoleDaoImpl.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/dao/RoleDaoImpl.java
@@ -1,0 +1,35 @@
+package np.com.krishnabk.springboot.demosecurity.dao;
+
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import np.com.krishnabk.springboot.demosecurity.entity.Role;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RoleDaoImpl implements RoleDao {
+
+    private EntityManager entityManager;
+
+    public RoleDaoImpl(EntityManager theEntityManager) {
+        entityManager = theEntityManager;
+    }
+
+    @Override
+    public Role findRoleByName(String theRoleName) {
+
+        // retrieve/read from database using name
+        TypedQuery<Role> theQuery = entityManager.createQuery("from Role where name=:roleName", Role.class);
+        theQuery.setParameter("roleName", theRoleName);
+
+        Role theRole = null;
+
+        try {
+            theRole = theQuery.getSingleResult();
+        } catch (Exception e) {
+            theRole = null;
+        }
+
+        return theRole;
+    }
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/dao/UserDao.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/dao/UserDao.java
@@ -1,0 +1,9 @@
+package np.com.krishnabk.springboot.demosecurity.dao;
+
+import np.com.krishnabk.springboot.demosecurity.entity.User;
+
+public interface UserDao {
+
+    User findByUserName(String userName);
+
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/dao/UserDaoImpl.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/dao/UserDaoImpl.java
@@ -1,0 +1,34 @@
+package np.com.krishnabk.springboot.demosecurity.dao;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import np.com.krishnabk.springboot.demosecurity.entity.User;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserDaoImpl implements UserDao {
+
+    private EntityManager entityManager;
+
+    public UserDaoImpl(EntityManager theEntityManager) {
+        this.entityManager = theEntityManager;
+    }
+
+    @Override
+    public User findByUserName(String theUserName) {
+
+        // retrieve/read from database using username
+        TypedQuery<User> theQuery = entityManager.createQuery("from User where userName=:uName and enabled=true", User.class);
+        theQuery.setParameter("uName", theUserName);
+
+        User theUser = null;
+        try {
+            theUser = theQuery.getSingleResult();
+        } catch (Exception e) {
+            theUser = null;
+        }
+
+        return theUser;
+    }
+
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/entity/Role.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/entity/Role.java
@@ -1,0 +1,47 @@
+package np.com.krishnabk.springboot.demosecurity.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "role")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    public Role() {
+    }
+
+    public Role(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "Role{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/entity/User.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/entity/User.java
@@ -1,0 +1,98 @@
+package np.com.krishnabk.springboot.demosecurity.entity;
+
+import jakarta.persistence.*;
+
+import java.util.Collection;
+
+@Entity
+@Table(name = "user")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "username")
+    private String userName;
+
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "enabled")
+    private boolean enabled;
+
+    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @JoinTable(name = "users_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
+    private Collection<Role> roles;
+
+    public User() {
+    }
+
+    public User(String userName, String password, boolean enabled) {
+        this.userName = userName;
+        this.password = password;
+        this.enabled = enabled;
+    }
+
+    public User(String userName, String password, boolean enabled,
+                Collection<Role> roles) {
+        this.userName = userName;
+        this.password = password;
+        this.enabled = enabled;
+        this.roles = roles;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Collection<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Collection<Role> roles) {
+        this.roles = roles;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", userName='" + userName + '\'' +
+                ", password='" + password + '\'' +
+                ", enabled=" + enabled +
+                ", roles=" + roles +
+                '}';
+    }
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
@@ -1,0 +1,53 @@
+package np.com.krishnabk.springboot.demosecurity.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
+import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class DemoSecurityConfig {
+
+    // add support for JDBC ... no more hard coded users
+    @Bean
+    public UserDetailsManager userDetailsManager(DataSource dataSource) {
+
+        JdbcUserDetailsManager jdbcUserDetailsManager = new JdbcUserDetailsManager(dataSource);
+
+        // for user info (must return username, password, enabled)
+        jdbcUserDetailsManager.setUsersByUsernameQuery(
+                "select user_id, pw, active from members where user_id=?");
+
+        // for authorities/roles (must return username, authority)
+        jdbcUserDetailsManager.setAuthoritiesByUsernameQuery(
+                "select user_id, role from roles where user_id=?");
+
+        return jdbcUserDetailsManager;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http.authorizeHttpRequests(configurer ->
+                        configurer
+                                .requestMatchers("/").hasRole("EMPLOYEE")
+                                .requestMatchers("/leaders/**").hasRole("MANAGER")
+                                .requestMatchers("/systems/**").hasRole("ADMIN")
+                                .anyRequest().authenticated()
+                )
+                .formLogin(form ->
+                        form
+                                .loginPage("/showMyLoginPage")
+                                .loginProcessingUrl("/authenticateTheUser")
+                                .permitAll()
+                )
+                .logout(logout -> logout.permitAll())
+                .exceptionHandling(configurer -> configurer
+                        .accessDeniedPage("/access-denied"));
+        return http.build();
+    }
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
@@ -1,8 +1,11 @@
 package np.com.krishnabk.springboot.demosecurity.security;
 
+import np.com.krishnabk.springboot.demosecurity.service.UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
@@ -11,6 +14,21 @@ import javax.sql.DataSource;
 
 @Configuration
 public class DemoSecurityConfig {
+
+    //bcrypt bean definition
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    //authenticationProvider bean definition
+    @Bean
+    public DaoAuthenticationProvider daoAuthenticationProvider(UserService userService) {
+        DaoAuthenticationProvider auth = new DaoAuthenticationProvider();
+        auth.setUserDetailsService(userService);
+        auth.setPasswordEncoder(passwordEncoder());
+        return auth;
+    }
 
     // add support for JDBC ... no more hard coded users
     @Bean

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/service/UserService.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/service/UserService.java
@@ -1,0 +1,10 @@
+package np.com.krishnabk.springboot.demosecurity.service;
+
+import np.com.krishnabk.springboot.demosecurity.entity.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+public interface UserService extends UserDetailsService {
+
+    public User findByUserName(String userName);
+
+}

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/service/UserServiceImpl.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/java/np/com/krishnabk/springboot/demosecurity/service/UserServiceImpl.java
@@ -1,0 +1,50 @@
+package np.com.krishnabk.springboot.demosecurity.service;
+
+import np.com.krishnabk.springboot.demosecurity.dao.RoleDao;
+import np.com.krishnabk.springboot.demosecurity.dao.UserDao;
+import np.com.krishnabk.springboot.demosecurity.entity.Role;
+import np.com.krishnabk.springboot.demosecurity.entity.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+@Service
+public class UserServiceImpl implements UserService {
+
+    private UserDao userDao;
+
+    private RoleDao roleDao;
+
+    @Autowired
+    public UserServiceImpl(UserDao userDao, RoleDao roleDao) {
+        this.userDao = userDao;
+        this.roleDao = roleDao;
+    }
+
+    @Override
+    public User findByUserName(String userName) {
+        // check the database if the user already exists
+        return userDao.findByUserName(userName);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String userName) throws UsernameNotFoundException {
+        User user = userDao.findByUserName(userName);
+        if (user == null) {
+            throw new UsernameNotFoundException("Invalid username or password.");
+        }
+        return new org.springframework.security.core.userdetails.User(user.getUserName(), user.getPassword(),
+                mapRolesToAuthorities(user.getRoles()));
+    }
+
+    private Collection<? extends GrantedAuthority> mapRolesToAuthorities(Collection<Role> roles) {
+        return roles.stream().map(role -> new SimpleGrantedAuthority(role.getName())).collect(Collectors.toList());
+    }
+}
+

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/application.properties
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+spring.application.name=demosecurity
+# JDBC Properties
+spring.datasource.url=jdbc:mysql://localhost:3306/employee_directory
+spring.datasource.username=springstudent
+spring.datasource.password=springstudent
+# Log JDBC SQL statements
+#
+# Only use this for dev/testing
+# Don't use for PRODUCTION since it will log usernames
+logging.level.org.springframework.jdbc.core=trace

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/access-denied.html
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/access-denied.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>KrishnaKompany - Access Denied</title>
+</head>
+<body>
+<h2>Access Denied - You are not authorized to access this resource.</h2>
+
+<hr>
+
+<a th:href="@{/}">Back to Home Page.</a>
+
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/fancy-login.html
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/fancy-login.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css"
+          integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" rel="stylesheet"/>
+    <style>
+        #loginbox {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100vh;
+            margin-top: 50px;
+            padding: 0;
+        }
+    </style>
+</head>
+
+<body>
+<div class="container">
+    <div class="col-md-3 col-md-offset-2 col-sm-6 col-sm-offset-2" id="loginbox">
+        <div class="card border-info">
+            <div class="card-header bg-info">
+                Sign In
+            </div>
+
+            <div class="card-body">
+                <div class="card-text">
+
+                    <!-- Login Form -->
+                    <form action="#" class="form-horizontal" method="POST" th:action="@{/authenticateTheUser}">
+
+                        <!-- Place for messages: error, alert etc ... -->
+                        <div class="form-group">
+                            <div class="col-xs-15">
+                                <div>
+                                    <!-- Check for login error -->
+                                    <div th:if="${param.error}">
+
+                                        <div class="alert alert-danger col-xs-offset-1 col-xs-10">
+                                            Invalid username and password.
+                                        </div>
+                                    </div>
+
+                                    <!-- Check for logout -->
+                                    <div th:if="${param.logout}">
+
+                                        <div class="alert alert-success col-xs-offset-1 col-xs-10">
+                                            You have been logged out.
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- User name -->
+                        <div class="input-group" style="margin-bottom: 25px;">
+                            <input class="form-control" name="username" placeholder="username" type="text"/>
+                        </div>
+
+                        <!-- Password -->
+                        <div class="input-group" style="margin-bottom: 25px;">
+                            <input class="form-control" name="password" placeholder="password" type="password"/>
+                        </div>
+
+                        <!-- Login/Submit Button -->
+                        <div class="form-group" style="margin-top: 10px;">
+                            <div class="col-sm-6 controls">
+                                <button class="btn btn-success" type="submit">Login</button>
+                            </div>
+                        </div>
+
+                    </form>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/home.html
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/home.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>KrishnaKompany Home Page</title>
+    <style>
+        input {
+            height: 30px;
+            border-radius: 5px;
+            border: none;
+            cursor: pointer;
+            background-color: rgba(147, 216, 255, 0.75);
+            padding: 8px;
+
+        }
+    </style>
+</head>
+<body>
+
+<h2>KrishnaKompany Home Page</h2>
+<hr>
+
+<p>Welcome to the KrishnaKompany home page!</p>
+
+<hr>
+
+<div sec:authorize="hasRole('EMPLOYEE')">
+    <!-- Display user name and role -->
+    <p>
+        User: <span sec:authentication="principal.username"></span>
+        <br><br>
+        Role: <span sec:authentication="principal.authorities"></span>
+    </p>
+</div>
+
+<div sec:authorize="hasRole('MANAGER')">
+    <!-- Add a link to point to /leader ... this is for the managers -->
+    <hr>
+    <p>
+        <a th:href="@{/leaders}">Leadership Meeting</a>
+        (Only for Manager peeps)
+    </p>
+</div>
+
+<div sec:authorize="hasRole('ADMIN')">
+    <!-- Add a link to point to /systems ... this is only for admins-->
+    <p>
+        <a th:href="@{/systems}">IT Systems Meeting</a>
+        (Only for Admin peeps)
+    </p>
+</div>
+
+<hr>
+<!-- Add a logout button-->
+<form action="#" method="POST" th:action="@{/logout}">
+    <input type="submit" value="Log Out">
+</form>
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/leaders.html
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/leaders.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>KrishnaKompany LEADERS Home Page</title>
+</head>
+<body>
+
+<h2>KrishnaKompany LEADERS Home Page</h2>
+
+<hr>
+
+<p>
+    See you in Indonesia ... for our annual leadership retreat!
+    <br>
+    Keep this trip a secret, don't tell the regular employees LOL :-)
+</p>
+
+<hr>
+
+<a th:href="@{/}">Back to home page</a>
+
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/plain-login.html
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/plain-login.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Login Page</title>
+    <style>
+        .error {
+            color: red;
+        }
+    </style>
+</head>
+<body>
+
+<h1>My Custom Login Page</h1>
+<hr>
+
+<form action="#" method="POST" th:action="@{/authenticateTheUser}">
+
+    <!-- Check for login error -->
+    <div th:if="${param.error}">
+        <i class="error">Sorry! You entered invalid username/password.</i>
+    </div>
+
+    <p>
+        User Name: <input name="username" type="text"/>
+    </p>
+    <p>
+        Password: <input name="password" type="password"/>
+    </p>
+    <input type="submit" value="Login">
+</form>
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/systems.html
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/main/resources/templates/systems.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>KrishnaKompany SYSTEMS Home Page</title>
+</head>
+<body>
+<h2>KrishnaKompany SYSTEMS Home Page</h2>
+<hr>
+
+<p>
+    We have annual holiday Caribbean cruise coming up. Register now!
+    <br>
+    Keep this trip a secret, don't tell the regular employees LOL :-)
+</p>
+
+<hr>
+<a th:href="@{/}">Back to Home Page</a>
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/test/java/np/com/krishnabk/springboot/demosecurity/DemosecurityApplicationTests.java
+++ b/08-sprinb-boot-spring-mvc-security/02-spring-boot-spring-mvc-security-jpa-hibernate-bcrypt/src/test/java/np/com/krishnabk/springboot/demosecurity/DemosecurityApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.springboot.demosecurity;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemosecurityApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
### Overview

This pull request updates the Spring Security configuration to use custom SQL queries for user authentication and role authorization with `JdbcUserDetailsManager`. It ensures compatibility with the application's existing `members` and `roles` tables.

### Details

- Sets a custom user query:  
  `select user_id, pw, active from members where user_id=?`  
  (Returns username, password, and enabled status)

- Sets a custom authorities/roles query:  
  `select user_id, role from roles where user_id=?`  
  (Returns username and authority/role)

- Ensures Spring Security can authenticate users and load their roles using the correct schema.

### Motivation

The default queries expect `users` and `authorities` tables, but this project uses `members` and `roles` with different column names. This change aligns Spring Security with the actual database schema.

### Notes

- Make sure the data in `members` and `roles` tables conforms to the expected structure and values.
- Passwords should be stored with the appropriate encoding (e.g., `{noop}` for development).