### PR TITLE
feat(user-registration, landing-page): implement user registration and custom landing page in Spring Security demo

### DIFF
--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/pom.xml
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.3</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.luv2code.springboot</groupId>
+	<artifactId>demosecurity</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>demosecurity</name>
+	<description>Demo project for Spring Boot</description>
+    <properties>
+        <java.version>21</java.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/sql-scripts/01-employee-directory.sql
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/sql-scripts/01-employee-directory.sql
@@ -1,0 +1,28 @@
+CREATE DATABASE  IF NOT EXISTS `employee_directory`;
+USE `employee_directory`;
+
+--
+-- Table structure for table `employee`
+--
+
+DROP TABLE IF EXISTS `employee`;
+
+CREATE TABLE `employee` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+--
+-- Data for table `employee`
+--
+
+INSERT INTO `employee` VALUES 
+	(1,'Leslie','Andrews','leslie@luv2code.com'),
+	(2,'Emma','Baumgarten','emma@luv2code.com'),
+	(3,'Avani','Gupta','avani@luv2code.com'),
+	(4,'Yuri','Petrov','yuri@luv2code.com'),
+	(5,'Juan','Vega','juan@luv2code.com');
+

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/sql-scripts/02-setup-spring-security-demo-database-hibernate-bcrypt.sql
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/sql-scripts/02-setup-spring-security-demo-database-hibernate-bcrypt.sql
@@ -1,0 +1,100 @@
+USE `employee_directory`;
+
+SET foreign_key_checks = 0;
+DROP TABLE IF EXISTS `user`;
+DROP TABLE IF EXISTS `role`;
+SET foreign_key_checks = 1;
+
+--
+-- Table structure for table `user`
+--
+
+DROP TABLE IF EXISTS `user`;
+
+CREATE TABLE `user` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `username` varchar(50) NOT NULL,
+  `password` char(80) NOT NULL,
+  `enabled` tinyint NOT NULL,  
+  `first_name` varchar(64) NOT NULL,
+  `last_name` varchar(64) NOT NULL,
+  `email` varchar(64) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+--
+-- Dumping data for table `user`
+--
+-- NOTE: The passwords are encrypted using BCrypt
+--
+-- A generation tool is avail at: http://www.luv2code.com/generate-bcrypt-password
+--
+-- Default passwords here are: fun123
+--
+
+INSERT INTO `user` (`username`,`password`,`enabled`, `first_name`, `last_name`, `email`)
+VALUES 
+('john','$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K',1,'John', 'Doe', 'john@luv2code.com'),
+('mary','$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K',1,'Mary', 'Smith', 'mary@luv2code.com'),
+('riya','$2a$04$eFytJDGtjbThXa80FyOOBuFdK2IwjyWefYkMpiBEFlpBwDH.5PM0K',1,'Susan', 'Public', 'susan@luv2code.com');
+
+
+--
+-- Table structure for table `role`
+--
+
+DROP TABLE IF EXISTS `role`;
+
+CREATE TABLE `role` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+--
+-- Dumping data for table `roles`
+--
+
+INSERT INTO `role` (name)
+VALUES 
+('ROLE_EMPLOYEE'),('ROLE_MANAGER'),('ROLE_ADMIN');
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+--
+-- Table structure for table `users_roles`
+--
+
+DROP TABLE IF EXISTS `users_roles`;
+
+CREATE TABLE `users_roles` (
+  `user_id` int NOT NULL,
+  `role_id` int NOT NULL,
+  
+  PRIMARY KEY (`user_id`,`role_id`),
+  
+  KEY `FK_ROLE_idx` (`role_id`),
+  
+  CONSTRAINT `FK_USER_05` FOREIGN KEY (`user_id`) 
+  REFERENCES `user` (`id`) 
+  ON DELETE NO ACTION ON UPDATE NO ACTION,
+  
+  CONSTRAINT `FK_ROLE` FOREIGN KEY (`role_id`) 
+  REFERENCES `role` (`id`) 
+  ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+--
+-- Dumping data for table `users_roles`
+--
+
+INSERT INTO `users_roles` (user_id,role_id)
+VALUES 
+(1, 1),
+(2, 1),
+(2, 2),
+(3, 1),
+(3, 2),
+(3, 3)

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/DemosecurityApplication.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/DemosecurityApplication.java
@@ -1,0 +1,13 @@
+package com.np.krishnabk.springboot.demosecurity;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemosecurityApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DemosecurityApplication.class, args);
+	}
+
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/controller/DemoController.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/controller/DemoController.java
@@ -1,0 +1,40 @@
+package com.np.krishnabk.springboot.demosecurity.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class DemoController {
+
+    @GetMapping("/")
+    public String showHome() {
+
+        return "home";
+    }
+
+    // add a request mapping for /leaders
+
+    @GetMapping("/leaders")
+    public String showLeaders() {
+
+        return "leaders";
+    }
+
+    // add request mapping for /systems
+
+    @GetMapping("/systems")
+    public String showSystems() {
+
+        return "systems";
+    }
+
+}
+
+
+
+
+
+
+
+
+

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/controller/LoginController.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/controller/LoginController.java
@@ -1,0 +1,33 @@
+package com.np.krishnabk.springboot.demosecurity.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class LoginController {
+
+    @GetMapping("/showMyLoginPage")
+    public String showMyLoginPage() {
+
+        return "fancy-login";
+    }
+
+    // add request mapping for /access-denied
+
+    @GetMapping("/access-denied")
+    public String showAccessDenied() {
+
+        return "access-denied";
+    }
+
+}
+
+
+
+
+
+
+
+
+
+

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/controller/RegistrationController.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/controller/RegistrationController.java
@@ -1,0 +1,86 @@
+package com.np.krishnabk.springboot.demosecurity.controller;
+
+import java.util.logging.Logger;
+
+import com.np.krishnabk.springboot.demosecurity.entity.User;
+import com.np.krishnabk.springboot.demosecurity.service.UserService;
+import com.np.krishnabk.springboot.demosecurity.user.WebUser;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.propertyeditors.StringTrimmerEditor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/register")
+public class RegistrationController {
+
+	private Logger logger = Logger.getLogger(getClass().getName());
+
+    private UserService userService;
+
+	@Autowired
+	public RegistrationController(UserService userService) {
+		this.userService = userService;
+	}
+
+	@InitBinder
+	public void initBinder(WebDataBinder dataBinder) {
+		
+		StringTrimmerEditor stringTrimmerEditor = new StringTrimmerEditor(true);
+		
+		dataBinder.registerCustomEditor(String.class, stringTrimmerEditor);
+	}	
+	
+	@GetMapping("/showRegistrationForm")
+	public String showMyLoginPage(Model theModel) {
+		
+		theModel.addAttribute("webUser", new WebUser());
+		
+		return "register/registration-form";
+	}
+
+	@PostMapping("/processRegistrationForm")
+	public String processRegistrationForm(
+			@Valid @ModelAttribute("webUser") WebUser theWebUser,
+			BindingResult theBindingResult,
+			HttpSession session, Model theModel) {
+
+		String userName = theWebUser.getUserName();
+		logger.info("Processing registration form for: " + userName);
+		
+		// form validation
+		 if (theBindingResult.hasErrors()){
+			 return "register/registration-form";
+		 }
+
+		// check the database if user already exists
+        User existing = userService.findByUserName(userName);
+        if (existing != null){
+        	theModel.addAttribute("webUser", new WebUser());
+			theModel.addAttribute("registrationError", "User name already exists.");
+
+			logger.warning("User name already exists.");
+        	return "register/registration-form";
+        }
+        
+        // create user account and store in the databse
+        userService.save(theWebUser);
+        
+        logger.info("Successfully created user: " + userName);
+
+		// place user in the web http session for later use
+		session.setAttribute("user", theWebUser);
+
+        return "register/registration-confirmation";
+	}
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/dao/RoleDao.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/dao/RoleDao.java
@@ -1,0 +1,9 @@
+package com.np.krishnabk.springboot.demosecurity.dao;
+
+import com.np.krishnabk.springboot.demosecurity.entity.Role;
+
+public interface RoleDao {
+
+	public Role findRoleByName(String theRoleName);
+	
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/dao/RoleDaoImpl.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/dao/RoleDaoImpl.java
@@ -1,0 +1,36 @@
+package com.np.krishnabk.springboot.demosecurity.dao;
+
+import com.np.krishnabk.springboot.demosecurity.entity.Role;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RoleDaoImpl implements RoleDao {
+
+	@Autowired
+	private EntityManager entityManager;
+
+	public RoleDaoImpl(EntityManager theEntityManager) {
+		entityManager = theEntityManager;
+	}
+
+	@Override
+	public Role findRoleByName(String theRoleName) {
+
+		// retrieve/read from database using name
+		TypedQuery<Role> theQuery = entityManager.createQuery("from Role where name=:roleName", Role.class);
+		theQuery.setParameter("roleName", theRoleName);
+		
+		Role theRole = null;
+		
+		try {
+			theRole = theQuery.getSingleResult();
+		} catch (Exception e) {
+			theRole = null;
+		}
+		
+		return theRole;
+	}
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/dao/UserDao.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/dao/UserDao.java
@@ -1,0 +1,10 @@
+package com.np.krishnabk.springboot.demosecurity.dao;
+
+import com.np.krishnabk.springboot.demosecurity.entity.User;
+
+public interface UserDao {
+
+    User findByUserName(String userName);
+
+    void save(User theUser);
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/dao/UserDaoImpl.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/dao/UserDaoImpl.java
@@ -1,0 +1,46 @@
+package com.np.krishnabk.springboot.demosecurity.dao;
+
+import com.np.krishnabk.springboot.demosecurity.entity.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class UserDaoImpl implements UserDao {
+
+	private EntityManager entityManager;
+
+	@Autowired
+	public UserDaoImpl(EntityManager theEntityManager) {
+		this.entityManager = theEntityManager;
+	}
+
+	@Override
+	public User findByUserName(String theUserName) {
+
+		// retrieve/read from database using username
+		TypedQuery<User> theQuery = entityManager.createQuery("from User where userName=:uName and enabled=true", User.class);
+		theQuery.setParameter("uName", theUserName);
+
+		User theUser = null;
+		try {
+			theUser = theQuery.getSingleResult();
+		} catch (Exception e) {
+			theUser = null;
+		}
+
+		return theUser;
+	}
+
+	@Override
+	@Transactional
+	public void save(User theUser) {
+
+		// create the user ... finally LOL
+		entityManager.merge(theUser);
+	}
+
+
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/entity/Role.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/entity/Role.java
@@ -1,0 +1,49 @@
+package com.np.krishnabk.springboot.demosecurity.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "role")
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    public Role() {
+    }
+
+    public Role(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "Role{" + "id=" + id + ", name='" + name + '\'' + '}';
+    }
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/entity/User.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/entity/User.java
@@ -1,0 +1,132 @@
+package com.np.krishnabk.springboot.demosecurity.entity;
+
+import jakarta.persistence.*;
+import java.util.Collection;
+
+@Entity
+@Table(name = "user")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "username")
+    private String userName;
+
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "enabled")
+    private boolean enabled;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
+
+    @Column(name = "email")
+    private String email;
+
+    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @JoinTable(name = "users_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id"))
+    private Collection<Role> roles;
+
+    public User() {
+    }
+
+    public User(String userName, String password, boolean enabled) {
+        this.userName = userName;
+        this.password = password;
+        this.enabled = enabled;
+    }
+
+    public User(String userName, String password, boolean enabled,
+                Collection<Role> roles) {
+        this.userName = userName;
+        this.password = password;
+        this.enabled = enabled;
+        this.roles = roles;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public Collection<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Collection<Role> roles) {
+        this.roles = roles;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", userName='" + userName + '\'' +
+                ", enabled=" + enabled +
+                ", firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", email='" + email + '\'' +
+                ", roles=" + roles +
+                '}';
+    }
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/security/CustomAuthenticationSuccessHandler.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/security/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,46 @@
+package com.np.krishnabk.springboot.demosecurity.security;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.np.krishnabk.springboot.demosecurity.entity.User;
+import com.np.krishnabk.springboot.demosecurity.service.UserService;
+
+@Component
+public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private UserService userService;
+
+    public CustomAuthenticationSuccessHandler(UserService theUserService) {
+        userService = theUserService;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+
+        System.out.println("In customAuthenticationSuccessHandler");
+
+        String userName = authentication.getName();
+
+        System.out.println("userName=" + userName);
+
+        User theUser = userService.findByUserName(userName);
+
+        // now place in the session
+        HttpSession session = request.getSession();
+        session.setAttribute("user", theUser);
+
+        // forward to home page
+        response.sendRedirect(request.getContextPath() + "/");
+    }
+
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
@@ -1,0 +1,58 @@
+package com.np.krishnabk.springboot.demosecurity.security;
+
+
+import com.np.krishnabk.springboot.demosecurity.service.UserService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+@Configuration
+public class DemoSecurityConfig {
+
+    //bcrypt bean definition
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    //authenticationProvider bean definition
+    @Bean
+    public DaoAuthenticationProvider authenticationProvider(UserService userService) {
+        DaoAuthenticationProvider auth = new DaoAuthenticationProvider();
+        auth.setUserDetailsService(userService); //set the custom user details service
+        auth.setPasswordEncoder(passwordEncoder()); //set the password encoder - bcrypt
+        return auth;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationSuccessHandler customAuthenticationSuccessHandler) throws Exception {
+
+        http.authorizeHttpRequests(configurer ->
+                        configurer
+                                .requestMatchers("/").hasRole("EMPLOYEE")
+                                .requestMatchers("/leaders/**").hasRole("MANAGER")
+                                .requestMatchers("/systems/**").hasRole("ADMIN")
+                                .requestMatchers("/register/**").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .formLogin(form ->
+                        form
+                                .loginPage("/showMyLoginPage")
+                                .loginProcessingUrl("/authenticateTheUser")
+                                .successHandler(customAuthenticationSuccessHandler)
+                                .permitAll()
+                )
+                .logout(logout -> logout.permitAll()
+                )
+                .exceptionHandling(configurer ->
+                        configurer.accessDeniedPage("/access-denied")
+                );
+
+        return http.build();
+    }
+
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/service/UserService.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/service/UserService.java
@@ -1,0 +1,13 @@
+package com.np.krishnabk.springboot.demosecurity.service;
+
+import com.np.krishnabk.springboot.demosecurity.entity.User;
+import com.np.krishnabk.springboot.demosecurity.user.WebUser;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+public interface UserService extends UserDetailsService {
+
+	public User findByUserName(String userName);
+
+	void save(WebUser webUser);
+
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/service/UserServiceImpl.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/service/UserServiceImpl.java
@@ -1,0 +1,84 @@
+package com.np.krishnabk.springboot.demosecurity.service;
+
+import com.np.krishnabk.springboot.demosecurity.dao.RoleDao;
+import com.np.krishnabk.springboot.demosecurity.dao.UserDao;
+import com.np.krishnabk.springboot.demosecurity.entity.Role;
+import com.np.krishnabk.springboot.demosecurity.entity.User;
+import com.np.krishnabk.springboot.demosecurity.user.WebUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+@Service
+public class UserServiceImpl implements UserService {
+
+	private UserDao userDao;
+
+	private RoleDao roleDao;
+
+	private BCryptPasswordEncoder passwordEncoder;
+
+	@Autowired
+	public UserServiceImpl(UserDao userDao, RoleDao roleDao, BCryptPasswordEncoder passwordEncoder) {
+		this.userDao = userDao;
+		this.roleDao = roleDao;
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	@Override
+	public User findByUserName(String userName) {
+		// check the database if the user already exists
+		return userDao.findByUserName(userName);
+	}
+
+	@Override
+	public void save(WebUser webUser) {
+		User user = new User();
+
+		// assign user details to the user object
+		user.setUserName(webUser.getUserName());
+		user.setPassword(passwordEncoder.encode(webUser.getPassword()));
+		user.setFirstName(webUser.getFirstName());
+		user.setLastName(webUser.getLastName());
+		user.setEmail(webUser.getEmail());
+		user.setEnabled(true);
+
+		// give user default role of "employee"
+		user.setRoles(Arrays.asList(roleDao.findRoleByName("ROLE_EMPLOYEE")));
+
+		// save user in the database
+		userDao.save(user);
+	}
+
+	@Override
+	public UserDetails loadUserByUsername(String userName) throws UsernameNotFoundException {
+		User user = userDao.findByUserName(userName);
+
+		if (user == null) {
+			throw new UsernameNotFoundException("Invalid username or password.");
+		}
+
+		Collection<SimpleGrantedAuthority> authorities = mapRolesToAuthorities(user.getRoles());
+
+		return new org.springframework.security.core.userdetails.User(user.getUserName(), user.getPassword(),
+				authorities);
+	}
+
+	private Collection<SimpleGrantedAuthority> mapRolesToAuthorities(Collection<Role> roles) {
+		Collection<SimpleGrantedAuthority> authorities = new ArrayList<>();
+
+		for (Role tempRole : roles) {
+			SimpleGrantedAuthority tempAuthority = new SimpleGrantedAuthority(tempRole.getName());
+			authorities.add(tempAuthority);
+		}
+
+		return authorities;
+	}
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/user/WebUser.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/java/com/np/krishnabk/springboot/demosecurity/user/WebUser.java
@@ -1,0 +1,74 @@
+package com.np.krishnabk.springboot.demosecurity.user;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class WebUser {
+
+	@NotNull(message = "is required")
+	@Size(min = 1, message = "is required")
+	private String userName;
+
+	@NotNull(message = "is required")
+	@Size(min = 1, message = "is required")
+	private String password;
+
+	@NotNull(message = "is required")
+	@Size(min = 1, message = "is required")
+	private String firstName;
+
+	@NotNull(message = "is required")
+	@Size(min = 1, message = "is required")
+	private String lastName;
+
+	@NotNull(message = "is required")
+	@Size(min = 1, message = "is required")
+	@Pattern(regexp="^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$")
+	private String email;
+
+	public WebUser() {
+
+	}
+
+	public String getUserName() {
+		return userName;
+	}
+
+	public void setUserName(String userName) {
+		this.userName = userName;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+}

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/application.properties
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+#
+# JDBC Properties
+#
+spring.datasource.url=jdbc:mysql://localhost:3306/employee_directory
+spring.datasource.username=springstudent
+spring.datasource.password=springstudent
+
+#
+# Log JDBC SQL statements
+#
+# Only use this for dev/testing
+# DO NOT use for PRODUCTION since it will log user names
+logging.level.org.springframework.jdbc.core=TRACE

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/access-denied.html
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/access-denied.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>luv2code - Access Denied</title>
+</head>
+<body>
+
+<h2>Access Denied - You are not authorized to access this resource.</h2>
+
+<hr>
+
+<a th:href="@{/}">Back to Home Page</a>
+
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/fancy-login.html
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/fancy-login.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <title>Login Page</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+</head>
+
+<body>
+
+<div class="container">
+
+    <div id="loginbox" style="margin-top: 50px;"
+         class="col-md-3 col-md-offset-2 col-sm-6 col-sm-offset-2">
+
+        <div class="card border-info">
+
+            <div class="card-header bg-info">
+                Sign In
+            </div>
+
+            <div class="card-body">
+
+                <div class="card-text">
+
+                    <!-- Login Form -->
+                    <form action="#" th:action="@{/authenticateTheUser}"
+                          method="POST" class="form-horizontal">
+
+                        <!-- Place for messages: error, alert etc ... -->
+                        <div class="form-group">
+                            <div class="col-xs-15">
+                                <div>
+
+                                    <!-- Check for login error -->
+
+                                    <div th:if="${param.error}">
+
+                                        <div class="alert alert-danger col-xs-offset-1 col-xs-10">
+                                            Invalid username and password.
+                                        </div>
+
+                                    </div>
+
+                                    <!-- Check for logout -->
+
+                                    <div th:if="${param.logout}">
+
+                                        <div class="alert alert-success col-xs-offset-1 col-xs-10">
+                                            You have been logged out.
+                                        </div>
+
+                                    </div>
+
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- User name -->
+                        <div style="margin-bottom: 25px" class="input-group">
+                            <input type="text" name="username" placeholder="username" class="form-control">
+                        </div>
+
+                        <!-- Password -->
+                        <div style="margin-bottom: 25px" class="input-group">
+                            <input type="password" name="password" placeholder="password" class="form-control">
+                        </div>
+
+                        <!-- Login/Submit Button -->
+                        <div style="margin-top: 10px" class="form-group">
+                            <div class="col-sm-6 controls">
+                                <button type="submit" class="btn btn-success">Login</button>
+                            </div>
+                        </div>
+
+                    </form>
+
+                </div>
+
+            </div>
+
+        </div>
+
+        <div>
+            <a th:href="@{/register/showRegistrationForm}" class="btn btn-primary mt-3" role="button" aria-pressed="true">Register New User</a>
+        </div>
+
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/home.html
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/home.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+
+<head>
+    <title>luv2code Company Home Page</title>
+</head>
+
+<body>
+<h2>luv2code Company Home Page</h2>
+<hr>
+
+<p>
+Welcome to the luv2code company home page!
+</p>
+
+<hr>
+
+<!-- display user name and role(s) -->
+
+<p>
+    User: <span sec:authentication="principal.username"></span>
+    <br><br>
+    Role(s): <span sec:authentication="principal.authorities"></span>
+
+    <!-- display first name, last name and email -->
+    <div th:if="${session.user}" >
+        <p th:text="'First name: ' + ${session.user.firstName} + ', Last name: ' + ${session.user.lastName} + ', Email: ' + ${session.user.email}"></p>
+    </div>
+
+</p>
+
+<div sec:authorize="hasRole('MANAGER')">
+
+    <!-- Add a link to point to /leaders ... this is for the managers -->
+    <p>
+        <a th:href="@{/leaders}">Leadership Meeting</a>
+        (Only for Manager peeps)
+    </p>
+
+</div>
+
+<div sec:authorize="hasRole('ADMIN')">
+
+    <!-- Add a link to point to /systems ... this is for the admins -->
+
+    <p>
+        <a th:href="@{/systems}">IT Systems Meeting</a>
+        (Only for Admin peeps)
+    </p>
+
+</div>
+
+<hr>
+
+<!-- Add a logout button -->
+<form action="#" th:action="@{/logout}"
+      method="POST">
+
+    <input type="submit" value="Logout" class="btn btn-outline-primary mt-2" />
+
+</form>
+
+
+</body>
+
+</html>

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/leaders.html
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/leaders.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>luv2code LEADERS Home Page</title>
+</head>
+<body>
+
+<h2>luv2code LEADERS Home Page</h2>
+
+<hr>
+
+<p>
+  See you in Brazil ... for our annual Leadership retreat!
+  <br>
+  Keep this trip a secret, don't tell the regular employees LOL :-)
+</p>
+
+<hr>
+
+<a th:href="@{/}">Back to Home Page</a>
+
+</body>
+</html>
+
+
+
+
+
+
+
+

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/register/registration-confirmation.html
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/register/registration-confirmation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+	<title>Registration Confirmation</title>
+</head>
+
+<body>
+
+	<h2>User registered successfully!</h2>
+
+	<!-- display first name, last name and email -->
+	<ul>
+		<li th:text="'User name: ' + ${webUser.userName}"></li>
+		<li th:text="'First name: ' + ${webUser.firstName}"></li>
+		<li th:text="'Last name: ' + ${webUser.lastName}"></li>
+		<li th:text="'Email name: ' + ${webUser.email}"></li>
+	</ul>
+
+	<hr>
+	
+	<a th:href="@{/showMyLoginPage}">Login with new user name</a>
+	
+</body>
+
+</html>

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/register/registration-form.html
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/register/registration-form.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <title>Registration Form</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+</head>
+
+<body>
+
+<div class="container">
+
+    <div id="loginbox" style="margin-top: 50px;"
+         class="col-md-3 col-md-offset-2 col-sm-6 col-sm-offset-2">
+
+        <div class="card border-info">
+
+            <div class="card-header bg-info">
+                New User Registration
+            </div>
+
+            <div class="card-body">
+
+                <div class="card-text">
+
+                    <!-- Registration Form -->
+                    <form action="#" th:action="@{/register/processRegistrationForm}"
+                          th:object="${webUser}"
+                          method="POST" class="form-horizontal">
+
+                        <!-- Place for messages: error, alert etc ... -->
+                        <div class="form-group">
+                            <div class="col-xs-15">
+                                <div>
+
+                                    <!-- Check for login error -->
+
+                                    <div th:if="${param.registrationError}">
+
+                                        <div class="alert alert-danger col-xs-offset-1 col-xs-10">
+                                            <span th:text="${param.registrationError}"></span>
+                                        </div>
+
+                                    </div>
+
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- User name -->
+                        <div style="margin-bottom: 25px" class="input-group">
+                            <input type="text" th:field="*{userName}" placeholder="Username (*)" class="form-control" />
+                        </div>
+
+                        <div th:if="${#fields.hasErrors('userName')}"
+                             style="margin-bottom: 25px" class="text-danger">
+                            <ul>
+                                <li th:each="err : ${#fields.errors('userName')}" th:text="'User name ' + ${err}" />
+                            </ul>
+                        </div>
+
+                        <!-- Password -->
+                        <div style="margin-bottom: 25px" class="input-group">
+                            <input type="text" th:field="*{password}" placeholder="Password (*)" class="form-control" />
+                        </div>
+
+                        <div th:if="${#fields.hasErrors('password')}"
+                             style="margin-bottom: 25px" class="text-danger">
+                            <ul>
+                                <li th:each="err : ${#fields.errors('password')}" th:text="'Password ' + ${err}" />
+                            </ul>
+                        </div>
+
+                        <!-- First Name -->
+                        <div style="margin-bottom: 25px" class="input-group">
+                            <input type="text" th:field="*{firstName}" placeholder="First name (*)" class="form-control" />
+                        </div>
+
+                        <div th:if="${#fields.hasErrors('firstName')}"
+                             style="margin-bottom: 25px" class="text-danger">
+                            <ul>
+                                <li th:each="err : ${#fields.errors('firstName')}" th:text="'First name ' + ${err}" />
+                            </ul>
+                        </div>
+
+                        <!-- Last Name -->
+                        <div style="margin-bottom: 25px" class="input-group">
+                            <input type="text" th:field="*{lastName}" placeholder="Last name (*)" class="form-control" />
+                        </div>
+
+                        <div th:if="${#fields.hasErrors('lastName')}"
+                             style="margin-bottom: 25px" class="text-danger">
+                            <ul>
+                                <li th:each="err : ${#fields.errors('lastName')}" th:text="'Last name ' + ${err}" />
+                            </ul>
+                        </div>
+
+                        <!-- Email -->
+                        <div style="margin-bottom: 25px" class="input-group">
+                            <input type="text" th:field="*{email}" placeholder="Email (*)" class="form-control" />
+                        </div>
+
+                        <div th:if="${#fields.hasErrors('email')}"
+                             style="margin-bottom: 25px" class="text-danger">
+                            <ul>
+                                <li th:each="err : ${#fields.errors('email')}" th:text="'Email ' + ${err}" />
+                            </ul>
+                        </div>
+
+                        <!-- Registration Button -->
+                        <div style="margin-top: 10px" class="form-group">
+                            <div class="col-sm-6 controls">
+                                <button type="submit" class="btn btn-primary">Register</button>
+                            </div>
+                        </div>
+
+                    </form>
+
+                </div>
+
+            </div>
+
+        </div>
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/systems.html
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/main/resources/templates/systems.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>luv2code SYSTEMS Home Page</title>
+</head>
+<body>
+
+<h2>luv2code SYSTEMS Home Page</h2>
+
+<hr>
+
+<p>
+  We have annual holiday Caribbean cruise coming up. Register now!
+  <br>
+  Keep this trip a secret, don't tell the regular employees LOL :-)
+</p>
+
+<hr>
+
+<a th:href="@{/}">Back to Home Page</a>
+
+</body>
+</html>
+
+
+
+
+
+
+
+

--- a/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/test/java/np/com/krishnabk/springboot/demosecurity/DemosecurityApplicationTests.java
+++ b/08-sprinb-boot-spring-mvc-security/03-spring-boot-spring-mvc-security-user-registration/src/test/java/np/com/krishnabk/springboot/demosecurity/DemosecurityApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.springboot.demosecurity;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemosecurityApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/pom.xml
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.0.4</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.luv2code.springboot</groupId>
+	<artifactId>demosecurity</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>demosecurity</name>
+	<description>Demo project for Spring Boot</description>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/java/np/com/krishnabk/springboot/demosecurity/DemosecurityApplication.java
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/java/np/com/krishnabk/springboot/demosecurity/DemosecurityApplication.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.springboot.demosecurity;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemosecurityApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DemosecurityApplication.class, args);
+	}
+
+}

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/DemoController.java
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/DemoController.java
@@ -1,0 +1,44 @@
+package np.com.krishnabk.springboot.demosecurity.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class DemoController {
+
+    @GetMapping("/")
+    public String showLanding() {
+        return "landing";
+    }
+
+    @GetMapping("/employees")
+    public String showHome() {
+        return "home";
+    }
+
+    // add a request mapping for /leaders
+
+    @GetMapping("/leaders")
+    public String showLeaders() {
+
+        return "leaders";
+    }
+
+    // add request mapping for /systems
+
+    @GetMapping("/systems")
+    public String showSystems() {
+
+        return "systems";
+    }
+
+}
+
+
+
+
+
+
+
+
+

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/LoginController.java
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/java/np/com/krishnabk/springboot/demosecurity/controller/LoginController.java
@@ -1,0 +1,33 @@
+package np.com.krishnabk.springboot.demosecurity.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class LoginController {
+
+    @GetMapping("/showMyLoginPage")
+    public String showMyLoginPage() {
+
+        return "fancy-login";
+    }
+
+    // add request mapping for /access-denied
+
+    @GetMapping("/access-denied")
+    public String showAccessDenied() {
+
+        return "access-denied";
+    }
+
+}
+
+
+
+
+
+
+
+
+
+

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/java/np/com/krishnabk/springboot/demosecurity/security/DemoSecurityConfig.java
@@ -1,0 +1,68 @@
+package np.com.krishnabk.springboot.demosecurity.security;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class DemoSecurityConfig {
+
+    @Bean
+    public InMemoryUserDetailsManager userDetailsManager() {
+
+        UserDetails john = User.builder()
+                .username("john")
+                .password("{noop}test123")
+                .roles("EMPLOYEE")
+                .build();
+
+        UserDetails mary = User.builder()
+                .username("mary")
+                .password("{noop}test123")
+                .roles("EMPLOYEE", "MANAGER")
+                .build();
+
+        UserDetails riya = User.builder()
+                .username("riya")
+                .password("{noop}test123")
+                .roles("EMPLOYEE", "MANAGER", "ADMIN")
+                .build();
+
+        return new InMemoryUserDetailsManager(john, mary, riya);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http.authorizeHttpRequests(configurer ->
+                        configurer
+                                .requestMatchers("/").permitAll()
+                                .requestMatchers("/employees/**").hasRole("EMPLOYEE")
+                                .requestMatchers("/leaders/**").hasRole("MANAGER")
+                                .requestMatchers("/systems/**").hasRole("ADMIN")
+                                .anyRequest().authenticated()
+                )
+                .formLogin(form ->
+                        form
+                                .loginPage("/showMyLoginPage")
+                                .loginProcessingUrl("/authenticateTheUser")
+                                .permitAll()
+                )
+                .logout(logout ->
+                        logout
+                                .permitAll()
+                                .logoutSuccessUrl("/")
+                )
+                .exceptionHandling(configurer ->
+                        configurer.accessDeniedPage("/access-denied")
+                );
+
+        return http.build();
+    }
+
+}

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/access-denied.html
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/access-denied.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>luv2code - Access Denied</title>
+</head>
+<body>
+
+<h2>Access Denied - You are not authorized to access this resource.</h2>
+
+<hr>
+
+<a th:href="@{/}">Back to Home Page</a>
+
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/fancy-login.html
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/fancy-login.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <title>Login Page</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Bootstrap demo</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+</head>
+
+<body>
+
+<div class="container">
+
+    <div id="loginbox" style="margin-top: 50px;"
+         class="col-md-3 col-md-offset-2 col-sm-6 col-sm-offset-2">
+
+        <div class="card border-info">
+
+            <div class="card-header bg-info">
+                Sign In
+            </div>
+
+            <div class="card-body">
+
+                <div class="card-text">
+
+                    <!-- Login Form -->
+                    <form action="#" th:action="@{/authenticateTheUser}"
+                          method="POST" class="form-horizontal">
+
+                        <!-- Place for messages: error, alert etc ... -->
+                        <div class="form-group">
+                            <div class="col-xs-15">
+                                <div>
+
+                                    <!-- Check for login error -->
+
+                                    <div th:if="${param.error}">
+
+                                        <div class="alert alert-danger col-xs-offset-1 col-xs-10">
+                                            Invalid username and password.
+                                        </div>
+
+                                    </div>
+
+                                    <!-- Check for logout -->
+
+                                    <div th:if="${param.logout}">
+
+                                        <div class="alert alert-success col-xs-offset-1 col-xs-10">
+                                            You have been logged out.
+                                        </div>
+
+                                    </div>
+
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- User name -->
+                        <div style="margin-bottom: 25px" class="input-group">
+                            <input type="text" name="username" placeholder="username" class="form-control">
+                        </div>
+
+                        <!-- Password -->
+                        <div style="margin-bottom: 25px" class="input-group">
+                            <input type="password" name="password" placeholder="password" class="form-control">
+                        </div>
+
+                        <!-- Login/Submit Button -->
+                        <div style="margin-top: 10px" class="form-group">
+                            <div class="col-sm-6 controls">
+                                <button type="submit" class="btn btn-success">Login</button>
+                            </div>
+                        </div>
+
+                    </form>
+
+                </div>
+
+            </div>
+
+        </div>
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/home.html
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/home.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+
+<head>
+    <title>luv2code Company Home Page</title>
+</head>
+
+<body>
+<h2>luv2code Company Home Page</h2>
+<hr>
+
+<p>
+Welcome to the luv2code company home page!
+</p>
+
+<hr>
+
+<!-- display user name and role(s) -->
+
+<p>
+    User: <span sec:authentication="principal.username"></span>
+    <br><br>
+    Role(s): <span sec:authentication="principal.authorities"></span>
+</p>
+
+<div sec:authorize="hasRole('MANAGER')">
+
+    <!-- Add a link to point to /leaders ... this is for the managers -->
+    <p>
+        <a th:href="@{/leaders}">Leadership Meeting</a>
+        (Only for Manager peeps)
+    </p>
+
+</div>
+
+<div sec:authorize="hasRole('ADMIN')">
+
+    <!-- Add a link to point to /systems ... this is for the admins -->
+
+    <p>
+        <a th:href="@{/systems}">IT Systems Meeting</a>
+        (Only for Admin peeps)
+    </p>
+
+</div>
+
+<hr>
+
+<!-- Add a logout button -->
+<form action="#" th:action="@{/logout}"
+      method="POST">
+
+    <input type="submit" value="Logout" class="btn btn-outline-primary mt-2" />
+
+</form>
+
+
+</body>
+
+</html>

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/landing.html
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/landing.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+
+<head>
+    <title>luv2code Landing Page</title>
+</head>
+
+<body>
+<h2>luv2code Landing Page</h2>
+<hr>
+
+<p>
+Welcome to the landing page! This page is open to the public ... no login required :-)
+</p>
+
+<hr>
+<p>
+    <a th:href="@{/employees}">Access Secure Site</a>
+</p>
+
+</body>
+</html>

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/leaders.html
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/leaders.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>luv2code LEADERS Home Page</title>
+</head>
+<body>
+
+<h2>luv2code LEADERS Home Page</h2>
+
+<hr>
+
+<p>
+  See you in Brazil ... for our annual Leadership retreat!
+  <br>
+  Keep this trip a secret, don't tell the regular employees LOL :-)
+</p>
+
+<hr>
+
+<a th:href="@{/}">Back to Home Page</a>
+
+</body>
+</html>
+
+
+
+
+
+
+
+

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/plain-login.html
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/plain-login.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <title>Custom Login Page</title>
+
+    <style>
+		.failed {
+			color: red;
+		}
+	</style>
+
+</head>
+
+<body>
+
+<h3>My Custom Login Page</h3>
+
+<form action="#" th:action="@{/authenticateTheUser}"
+           method="POST">
+
+    <!-- Check for login error -->
+
+    <div th:if="${param.error}">
+
+        <i class="failed">Sorry! You entered invalid username/password.</i>
+
+    </div>
+
+    <p>
+        User name: <input type="text" name="username" />
+    </p>
+
+    <p>
+        Password: <input type="password" name="password" />
+    </p>
+
+    <input type="submit" value="Login" />
+
+</form>
+
+</body>
+
+</html>

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/systems.html
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/main/resources/templates/systems.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>luv2code SYSTEMS Home Page</title>
+</head>
+<body>
+
+<h2>luv2code SYSTEMS Home Page</h2>
+
+<hr>
+
+<p>
+  We have annual holiday Caribbean cruise coming up. Register now!
+  <br>
+  Keep this trip a secret, don't tell the regular employees LOL :-)
+</p>
+
+<hr>
+
+<a th:href="@{/}">Back to Home Page</a>
+
+</body>
+</html>
+
+
+
+
+
+
+
+

--- a/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/test/java/np/com/krishnabk/springboot/demosecurity/DemosecurityApplicationTests.java
+++ b/08-sprinb-boot-spring-mvc-security/04-spring-boot-spring-mvc-security-landing-page/src/test/java/np/com/krishnabk/springboot/demosecurity/DemosecurityApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.springboot.demosecurity;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemosecurityApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
### Overview

This pull request introduces user registration functionality and a custom landing page to the Spring Security demo application.

---

#### **User Registration**
- Added JPA entities for `User` and `Role`
- Implemented DAO layers and service logic for user and role management
- Integrated BCrypt password encoding for secure password storage
- Created controllers for login, demo, and user registration flows
- Added custom authentication success handler
- Included SQL scripts for database setup and BCrypt integration
- Added registration and login HTML templates
- Configured application properties for database and security
- Added an initial test class for the application context

---

#### **Landing Page & Login Enhancements**
- Added a new `landing.html` template as the application's entry point
- Implemented both plain and fancy login page templates
- Updated `DemoSecurityConfig` for custom login and access denied handling
- Added `DemoController` and `LoginController` for routing
- Updated application properties for security and view configuration
- Included additional security-protected templates (home, leaders, systems)
- Added an initial test class for application context

---

**Motivation:**  
These changes enhance the demo application by providing a full user registration workflow and a polished first-time experience with a custom landing page and multiple login styles.