### PR TITLE
feat(jpa-one-to-one): implement one-to-one mapping with Instructor and InstructorDetail entities, DAO abstraction, and enhanced SQL logging

### DIFF
--- a/09-spring-boot-jpa-advanced-mappings/00-jpa-advanced-mappings-database-scripts/hb-01-one-to-one-uni/create-db.sql
+++ b/09-spring-boot-jpa-advanced-mappings/00-jpa-advanced-mappings-database-scripts/hb-01-one-to-one-uni/create-db.sql
@@ -1,0 +1,28 @@
+DROP SCHEMA IF EXISTS `hb-01-one-to-one-uni`;
+
+CREATE SCHEMA `hb-01-one-to-one-uni`;
+
+use `hb-01-one-to-one-uni`;
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE `instructor_detail` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `youtube_channel` varchar(128) DEFAULT NULL,
+  `hobby` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+
+CREATE TABLE `instructor` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  `instructor_detail_id` int DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK_DETAIL_idx` (`instructor_detail_id`),
+  CONSTRAINT `FK_DETAIL` FOREIGN KEY (`instructor_detail_id`) REFERENCES `instructor_detail` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/09-spring-boot-jpa-advanced-mappings/00-jpa-advanced-mappings-database-scripts/hb-02-one-to-one-bi/create-db.sql
+++ b/09-spring-boot-jpa-advanced-mappings/00-jpa-advanced-mappings-database-scripts/hb-02-one-to-one-bi/create-db.sql
@@ -1,0 +1,28 @@
+DROP SCHEMA IF EXISTS `hb-01-one-to-one-uni`;
+
+CREATE SCHEMA `hb-01-one-to-one-uni`;
+
+use `hb-01-one-to-one-uni`;
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE `instructor_detail` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `youtube_channel` varchar(128) DEFAULT NULL,
+  `hobby` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+
+CREATE TABLE `instructor` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  `instructor_detail_id` int DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK_DETAIL_idx` (`instructor_detail_id`),
+  CONSTRAINT `FK_DETAIL` FOREIGN KEY (`instructor_detail_id`) REFERENCES `instructor_detail` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/09-spring-boot-jpa-advanced-mappings/00-jpa-advanced-mappings-database-scripts/hb-03-one-to-many/create-db.sql
+++ b/09-spring-boot-jpa-advanced-mappings/00-jpa-advanced-mappings-database-scripts/hb-03-one-to-many/create-db.sql
@@ -1,0 +1,54 @@
+DROP SCHEMA IF EXISTS `hb-03-one-to-many`;
+
+CREATE SCHEMA `hb-03-one-to-many`;
+
+use `hb-03-one-to-many`;
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+DROP TABLE IF EXISTS `instructor_detail`;
+
+CREATE TABLE `instructor_detail` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `youtube_channel` varchar(128) DEFAULT NULL,
+  `hobby` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+
+DROP TABLE IF EXISTS `instructor`;
+
+CREATE TABLE `instructor` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  `instructor_detail_id` int DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK_DETAIL_idx` (`instructor_detail_id`),
+  CONSTRAINT `FK_DETAIL` FOREIGN KEY (`instructor_detail_id`) 
+  REFERENCES `instructor_detail` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+DROP TABLE IF EXISTS `course`;
+
+CREATE TABLE `course` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `title` varchar(128) DEFAULT NULL,
+  `instructor_id` int DEFAULT NULL,
+  
+  PRIMARY KEY (`id`),
+  
+  UNIQUE KEY `TITLE_UNIQUE` (`title`),
+  
+  KEY `FK_INSTRUCTOR_idx` (`instructor_id`),
+  
+  CONSTRAINT `FK_INSTRUCTOR` 
+  FOREIGN KEY (`instructor_id`) 
+  REFERENCES `instructor` (`id`) 
+  
+  ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=latin1;
+
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/09-spring-boot-jpa-advanced-mappings/00-jpa-advanced-mappings-database-scripts/hb-04-one-to-many-uni/create-db.sql
+++ b/09-spring-boot-jpa-advanced-mappings/00-jpa-advanced-mappings-database-scripts/hb-04-one-to-many-uni/create-db.sql
@@ -1,0 +1,66 @@
+DROP SCHEMA IF EXISTS `hb-04-one-to-many-uni`;
+
+CREATE SCHEMA `hb-04-one-to-many-uni`;
+
+use `hb-04-one-to-many-uni`;
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE `instructor_detail` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `youtube_channel` varchar(128) DEFAULT NULL,
+  `hobby` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+
+CREATE TABLE `instructor` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  `instructor_detail_id` int DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK_DETAIL_idx` (`instructor_detail_id`),
+  CONSTRAINT `FK_DETAIL` FOREIGN KEY (`instructor_detail_id`) 
+  REFERENCES `instructor_detail` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+
+CREATE TABLE `course` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `title` varchar(128) DEFAULT NULL,
+  `instructor_id` int DEFAULT NULL,
+  
+  PRIMARY KEY (`id`),
+  
+  UNIQUE KEY `TITLE_UNIQUE` (`title`),
+  
+  KEY `FK_INSTRUCTOR_idx` (`instructor_id`),
+  
+  CONSTRAINT `FK_INSTRUCTOR` 
+  FOREIGN KEY (`instructor_id`) 
+  REFERENCES `instructor` (`id`) 
+  
+  ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=latin1;
+
+
+CREATE TABLE `review` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `comment` varchar(256) DEFAULT NULL,
+  `course_id` int DEFAULT NULL,
+
+  PRIMARY KEY (`id`),
+
+  KEY `FK_COURSE_ID_idx` (`course_id`),
+
+  CONSTRAINT `FK_COURSE` 
+  FOREIGN KEY (`course_id`) 
+  REFERENCES `course` (`id`) 
+
+  ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/09-spring-boot-jpa-advanced-mappings/00-jpa-advanced-mappings-database-scripts/hb-05-many-to-many/create-db.sql
+++ b/09-spring-boot-jpa-advanced-mappings/00-jpa-advanced-mappings-database-scripts/hb-05-many-to-many/create-db.sql
@@ -1,0 +1,92 @@
+DROP SCHEMA IF EXISTS `hb-05-many-to-many`;
+
+CREATE SCHEMA `hb-05-many-to-many`;
+
+use `hb-05-many-to-many`;
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE `instructor_detail` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `youtube_channel` varchar(128) DEFAULT NULL,
+  `hobby` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+
+CREATE TABLE `instructor` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  `instructor_detail_id` int DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK_DETAIL_idx` (`instructor_detail_id`),
+  CONSTRAINT `FK_DETAIL` FOREIGN KEY (`instructor_detail_id`) 
+  REFERENCES `instructor_detail` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+
+CREATE TABLE `course` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `title` varchar(128) DEFAULT NULL,
+  `instructor_id` int DEFAULT NULL,
+  
+  PRIMARY KEY (`id`),
+  
+  UNIQUE KEY `TITLE_UNIQUE` (`title`),
+  
+  KEY `FK_INSTRUCTOR_idx` (`instructor_id`),
+  
+  CONSTRAINT `FK_INSTRUCTOR` 
+  FOREIGN KEY (`instructor_id`) 
+  REFERENCES `instructor` (`id`) 
+  
+  ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=latin1;
+
+
+CREATE TABLE `review` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `comment` varchar(256) DEFAULT NULL,
+  `course_id` int DEFAULT NULL,
+
+  PRIMARY KEY (`id`),
+
+  KEY `FK_COURSE_ID_idx` (`course_id`),
+
+  CONSTRAINT `FK_COURSE` 
+  FOREIGN KEY (`course_id`) 
+  REFERENCES `course` (`id`) 
+
+  ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+
+CREATE TABLE `student` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `first_name` varchar(45) DEFAULT NULL,
+  `last_name` varchar(45) DEFAULT NULL,
+  `email` varchar(45) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+
+
+CREATE TABLE `course_student` (
+  `course_id` int NOT NULL,
+  `student_id` int NOT NULL,
+  
+  PRIMARY KEY (`course_id`,`student_id`),
+  
+  KEY `FK_STUDENT_idx` (`student_id`),
+  
+  CONSTRAINT `FK_COURSE_05` FOREIGN KEY (`course_id`) 
+  REFERENCES `course` (`id`) 
+  ON DELETE NO ACTION ON UPDATE NO ACTION,
+  
+  CONSTRAINT `FK_STUDENT` FOREIGN KEY (`student_id`) 
+  REFERENCES `student` (`id`) 
+  ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/.gitattributes
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/.gitignore
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>np.com.krishnabk</groupId>
+    <artifactId>cruddemo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>01-jpa-one-to-one-uni</name>
+    <description>01-jpa-one-to-one-uni</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,5 +1,8 @@
 package np.com.krishnabk.cruddemo;
 
+import np.com.krishnabk.cruddemo.dao.AppDAO;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -13,10 +16,33 @@ public class Application {
     }
 
     @Bean
-    public CommandLineRunner commandLineRunner(String[] args){
+    public CommandLineRunner commandLineRunner(AppDAO appDAO){
 
         return runner -> {
-            System.out.println("Hello, World!");
+            createInstructor(appDAO);
         };
     }
+
+    private void createInstructor(AppDAO appDAO) {
+
+        // create the instructor
+        Instructor tempInstructor = new Instructor(
+                "Krishna", "Bishowkarma", "hi@krishna-bk.com.np"
+        );
+
+        // create the instructor detail
+        InstructorDetail tempInstructorDetail = new InstructorDetail(
+                "https://www.youtube.com/@krishnabkarma","Filmmaking"
+        );
+
+        // associate the objects
+        tempInstructor.setInstructorDetail(tempInstructorDetail);
+
+        // save the objects
+        // NOTE: this will also save the details object because of CascadeType.ALL
+        System.out.println("Saving Instructor: " + tempInstructor);
+        appDAO.save(tempInstructor);
+        System.out.println("Done!");
+    }
+
 }

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.cruddemo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,7 +1,9 @@
 package np.com.krishnabk.cruddemo;
 
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class Application {
@@ -10,4 +12,11 @@ public class Application {
         SpringApplication.run(Application.class, args);
     }
 
+    @Bean
+    public CommandLineRunner commandLineRunner(String[] args){
+
+        return runner -> {
+            System.out.println("Hello, World!");
+        };
+    }
 }

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -1,0 +1,9 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import np.com.krishnabk.cruddemo.entity.Instructor;
+
+public interface AppDAO {
+
+    void save(Instructor theInstructor);
+
+}

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -1,0 +1,27 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import jakarta.persistence.EntityManager;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class AppDAOImpl implements AppDAO{
+
+    // define field for entity manager
+    private EntityManager entityManager;
+
+    // inject entity manager using constructor injection
+    @Autowired
+    public AppDAOImpl(EntityManager entityManager){
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    @Transactional
+    public void save(Instructor theInstructor) {
+        entityManager.persist(theInstructor);
+
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
@@ -1,0 +1,99 @@
+    package np.com.krishnabk.cruddemo.entity;
+
+    import jakarta.persistence.*;
+
+    @Entity
+    @Table(name = "instructor")
+    public class Instructor {
+
+        // step 1. annotate the class as an entity and map to db table
+
+        // step 2. define table fields
+
+        // step 3. annotate the fields with db column names
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "id")
+        private int id;
+
+        @Column(name = "first_name")
+        private String firstName;
+
+        @Column(name = "last_name")
+        private String lastName;
+
+        @Column(name = "email")
+        private String email;
+
+        // set up mapping to InstructorDetail entity
+
+        @OneToOne(cascade = CascadeType.ALL)
+        @JoinColumn(name = "instructor_detail_id")
+        private InstructorDetail instructorDetail;
+
+        // step 4. create constructors
+
+        public Instructor(){}
+
+        public Instructor(String firstName, String lastName, String email) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.email = email;
+        }
+
+        // step 5. generate getters/setters methods
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public InstructorDetail getInstructorDetail() {
+            return instructorDetail;
+        }
+
+        public void setInstructorDetail(InstructorDetail instructorDetail) {
+            this.instructorDetail = instructorDetail;
+        }
+
+        // step 6. generate toString() method
+
+        @Override
+        public String toString() {
+            return "Instructor{" +
+                    "id=" + id +
+                    ", firstName='" + firstName + '\'' +
+                    ", lastName='" + lastName + '\'' +
+                    ", email='" + email + '\'' +
+                    ", instructorDetail=" + instructorDetail +
+                    '}';
+        }
+    }

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
@@ -1,0 +1,70 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "instructor_detail")
+public class InstructorDetail {
+
+
+    // step 1. annotate the class as an entity and map to db table
+    // step 2. define table fields
+    // step 3. annotate the fields with db column names
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "youtube_channel")
+    private String youtubeChannel;
+
+    @Column(name = "hobby")
+    private String hobby;
+
+    // step 4. create constructors
+    public InstructorDetail(){
+
+    }
+
+    public InstructorDetail(String youtubeChannel, String hobby) {
+        this.youtubeChannel = youtubeChannel;
+        this.hobby = hobby;
+    }
+
+    // step 5. generate getters/setters methods
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getYoutubeChannel() {
+        return youtubeChannel;
+    }
+
+    public void setYoutubeChannel(String youtubeChannel) {
+        this.youtubeChannel = youtubeChannel;
+    }
+
+    public String getHobby() {
+        return hobby;
+    }
+
+    public void setHobby(String hobby) {
+        this.hobby = hobby;
+    }
+
+    // step 6. generate toString() method
+
+    @Override
+    public String  toString() {
+        return "InstructorDetail{" +
+                "id=" + id +
+                ", youtubeChannel='" + youtubeChannel + '\'' +
+                ", hobby='" + hobby + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/resources/application.properties
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/resources/application.properties
@@ -8,3 +8,8 @@ spring.main.banner-mode=off
 
 # Reduce logging level. Set logging level to warn
 logging.level.root=warn
+
+
+# Show JPA/Hibernate logging message
+logging.level.org.hibernate.sql=trace
+logging.level.org.hibernate.orm.jdbc.bind=trace

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/resources/application.properties
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=01-jpa-one-to-one-uni

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/resources/application.properties
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/resources/application.properties
@@ -1,1 +1,10 @@
 spring.application.name=01-jpa-one-to-one-uni
+spring.datasource.url=jdbc:mysql://localhost:3306/hb-01-one-to-one-uni
+spring.datasource.username=springstudent
+spring.datasource.password=springstudent
+
+# Turn off the Spring Boot Banner
+spring.main.banner-mode=off
+
+# Reduce logging level. Set logging level to warn
+logging.level.root=warn

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/test/java/np/com/krishnabk/cruddemo/ApplicationTests.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/test/java/np/com/krishnabk/cruddemo/ApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.cruddemo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
### Overview

- Implements JPA one-to-one unidirectional mapping between `Instructor` and `InstructorDetail` entities.
- Introduces `AppDAO` interface and its implementation (`AppDAOImpl`) to abstract persistence logic for instructors.
- Refactors `Application.java` to create and persist an `Instructor` together with its associated `InstructorDetail` via the DAO.
- Updates `application.properties` to enable detailed Hibernate SQL and JDBC bind logging for improved visibility and learning.

### Details

- `Instructor` and `InstructorDetail` are linked with a one-to-one relationship using JPA annotations and cascade operations.
- The application now, on startup, demonstrates saving an instructor and its detail in a single transaction.
- DAO pattern used for better separation of concerns.
- SQL and parameter logs provide a transparent view of Hibernate operations, aiding debugging and understanding of JPA mappings.
