### PR TITLE
feat(jpa-one-to-one): add instructor deletion and retrieval by ID via DAO abstraction

### DIFF
--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -19,8 +19,20 @@ public class Application {
     public CommandLineRunner commandLineRunner(AppDAO appDAO){
 
         return runner -> {
-            createInstructor(appDAO);
+//            createInstructor(appDAO);
+            findInstructor(appDAO);
+
         };
+    }
+
+    private void findInstructor(AppDAO appDAO) {
+        int theId = 1;
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor  = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        System.out.println("the associated instructorDetail only: " + tempInstructor.getInstructorDetail());
     }
 
     private void createInstructor(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -43,7 +43,11 @@ public class Application {
         Instructor tempInstructor  = appDAO.findInstructorById(theId);
 
         System.out.println("tempInstructor: " + tempInstructor);
-        System.out.println("the associated instructorDetail only: " + tempInstructor.getInstructorDetail());
+        if (tempInstructor != null) {
+            System.out.println("the associated instructorDetail only: " + tempInstructor.getInstructorDetail());
+        } else {
+            System.out.println("Instructor not found with id: " + theId);
+        }
     }
 
     private void createInstructor(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -20,9 +20,20 @@ public class Application {
 
         return runner -> {
 //            createInstructor(appDAO);
-            findInstructor(appDAO);
+//            findInstructor(appDAO);
+            deleteInstructor(appDAO);
 
         };
+    }
+
+    private void deleteInstructor(AppDAO appDAO) {
+
+        int theId = 1;
+        System.out.println("Deleting instructor id: " + theId);
+
+        appDAO.deleteInstructorById(theId);
+
+        System.out.println("Done!");
     }
 
     private void findInstructor(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -6,4 +6,5 @@ public interface AppDAO {
 
     void save(Instructor theInstructor);
 
+    Instructor findInstructorById(int theId);
 }

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -7,4 +7,6 @@ public interface AppDAO {
     void save(Instructor theInstructor);
 
     Instructor findInstructorById(int theId);
+
+    void deleteInstructorById(int theId);
 }

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -37,8 +37,10 @@ public class AppDAOImpl implements AppDAO{
         // retrieve the instructor
         Instructor tempInstructor = entityManager.find(Instructor.class, theId);
 
-        // delete the instructor
-        entityManager.remove(tempInstructor);
+        // delete the instructor if found
+        if (tempInstructor != null) {
+            entityManager.remove(tempInstructor);
+        }
     }
 
 }

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -24,4 +24,9 @@ public class AppDAOImpl implements AppDAO{
         entityManager.persist(theInstructor);
 
     }
+
+    @Override
+    public Instructor findInstructorById(int theId) {
+        return entityManager.find(Instructor.class, theId);
+    }
 }

--- a/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/01-jpa-one-to-one-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -29,4 +29,16 @@ public class AppDAOImpl implements AppDAO{
     public Instructor findInstructorById(int theId) {
         return entityManager.find(Instructor.class, theId);
     }
+
+    @Override
+    @Transactional
+    public void deleteInstructorById(int theId) {
+
+        // retrieve the instructor
+        Instructor tempInstructor = entityManager.find(Instructor.class, theId);
+
+        // delete the instructor
+        entityManager.remove(tempInstructor);
+    }
+
 }


### PR DESCRIPTION
### Overview

- Implements retrieval and deletion operations for the JPA One-to-One unidirectional mapping between `Instructor` and `InstructorDetail`.
- Adds `findInstructorById` and `deleteInstructorById` methods to `AppDAO` and `AppDAOImpl`.
- Updates `Application.java` to demonstrate fetching and deleting an `Instructor` with its associated `InstructorDetail` from the database.
- Previous logic for instructor creation is commented out to focus on demonstration of retrieval and deletion.

### Details

- `AppDAO` interface and its implementation now support both finding and deleting instructors by their ID.
- Demonstrates how to retrieve and remove entities in a one-to-one relationship, which is critical for understanding JPA cascading and entity lifecycle.
- Enhances the learning module for advanced JPA mappings by covering essential CRUD operations.