### PR TITLE
JPA One-to-One Bidirectional Mapping: Project Initialization, Retrieval, and Deletion Enhancements

### DIFF
--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/.gitattributes
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/.gitignore
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>np.com.krishnabk</groupId>
+    <artifactId>cruddemo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>02-jpa-one-to-one-bi</name>
+    <description>02-jpa-one-to-one-bi</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -29,7 +29,7 @@ public class Application {
 
     private void deleteInstructorDetail(AppDAO appDAO) {
 
-        int theId = 2;
+        int theId = 3;
         System.out.println("Deleting instructor id: " + theId);
 
         appDAO.deleteInstructorDetailById(theId);

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -22,8 +22,20 @@ public class Application {
 //            createInstructor(appDAO);
 //            findInstructor(appDAO);
 //            deleteInstructor(appDAO);
-            findInstructorDetail(appDAO);
+//            findInstructorDetail(appDAO);
+            deleteInstructorDetail(appDAO);
         };
+    }
+
+    private void deleteInstructorDetail(AppDAO appDAO) {
+
+        int theId = 2;
+        System.out.println("Deleting instructor id: " + theId);
+
+        appDAO.deleteInstructorDetailById(theId);
+
+        System.out.println("Done!");
+
     }
 
     private void findInstructorDetail(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -21,9 +21,24 @@ public class Application {
         return runner -> {
 //            createInstructor(appDAO);
 //            findInstructor(appDAO);
-            deleteInstructor(appDAO);
-
+//            deleteInstructor(appDAO);
+            findInstructorDetail(appDAO);
         };
+    }
+
+    private void findInstructorDetail(AppDAO appDAO) {
+
+        // get the instructor detail object
+        int theId = 1;
+        InstructorDetail tempInstructorDetail = appDAO.findInstructorDetailById(theId);
+
+        // print the instructor detail
+        System.out.println("tempInstructorDetail: " + tempInstructorDetail);
+
+        // print the associated instructor
+        System.out.println("The associated instructor: " + tempInstructorDetail.getInstructor());
+
+        System.out.println("Done!");
     }
 
     private void deleteInstructor(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,0 +1,75 @@
+package np.com.krishnabk.cruddemo;
+
+import np.com.krishnabk.cruddemo.dao.AppDAO;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    public CommandLineRunner commandLineRunner(AppDAO appDAO){
+
+        return runner -> {
+//            createInstructor(appDAO);
+//            findInstructor(appDAO);
+            deleteInstructor(appDAO);
+
+        };
+    }
+
+    private void deleteInstructor(AppDAO appDAO) {
+
+        int theId = 1;
+        System.out.println("Deleting instructor id: " + theId);
+
+        appDAO.deleteInstructorById(theId);
+
+        System.out.println("Done!");
+    }
+
+    private void findInstructor(AppDAO appDAO) {
+        int theId = 1;
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor  = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        if (tempInstructor != null) {
+            System.out.println("the associated instructorDetail only: " + tempInstructor.getInstructorDetail());
+        } else {
+            System.out.println("Instructor not found with id: " + theId);
+        }
+    }
+
+    private void createInstructor(AppDAO appDAO) {
+
+        // create the instructor
+        Instructor tempInstructor = new Instructor(
+                "Krishna", "Bishowkarma", "hi@krishna-bk.com.np"
+        );
+
+        // create the instructor detail
+        InstructorDetail tempInstructorDetail = new InstructorDetail(
+                "https://www.youtube.com/@krishnabkarma","Filmmaking"
+        );
+
+        // associate the objects
+        tempInstructor.setInstructorDetail(tempInstructorDetail);
+
+        // save the objects
+        // NOTE: this will also save the details object because of CascadeType.ALL
+        System.out.println("Saving Instructor: " + tempInstructor);
+        appDAO.save(tempInstructor);
+        System.out.println("Done!");
+    }
+
+}

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -1,0 +1,12 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import np.com.krishnabk.cruddemo.entity.Instructor;
+
+public interface AppDAO {
+
+    void save(Instructor theInstructor);
+
+    Instructor findInstructorById(int theId);
+
+    void deleteInstructorById(int theId);
+}

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -12,4 +12,6 @@ public interface AppDAO {
     void deleteInstructorById(int theId);
 
     InstructorDetail findInstructorDetailById(int theId);
+
+    void deleteInstructorDetailById(int theId);
 }

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -1,6 +1,7 @@
 package np.com.krishnabk.cruddemo.dao;
 
 import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
 
 public interface AppDAO {
 
@@ -9,4 +10,6 @@ public interface AppDAO {
     Instructor findInstructorById(int theId);
 
     void deleteInstructorById(int theId);
+
+    InstructorDetail findInstructorDetailById(int theId);
 }

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -1,0 +1,46 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import jakarta.persistence.EntityManager;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class AppDAOImpl implements AppDAO{
+
+    // define field for entity manager
+    private EntityManager entityManager;
+
+    // inject entity manager using constructor injection
+    @Autowired
+    public AppDAOImpl(EntityManager entityManager){
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    @Transactional
+    public void save(Instructor theInstructor) {
+        entityManager.persist(theInstructor);
+
+    }
+
+    @Override
+    public Instructor findInstructorById(int theId) {
+        return entityManager.find(Instructor.class, theId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteInstructorById(int theId) {
+
+        // retrieve the instructor
+        Instructor tempInstructor = entityManager.find(Instructor.class, theId);
+
+        // delete the instructor if found
+        if (tempInstructor != null) {
+            entityManager.remove(tempInstructor);
+        }
+    }
+
+}

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -62,7 +62,9 @@ public class AppDAOImpl implements AppDAO{
 
         // break bi-directional link
 
-        tempInstructorDetail.getInstructor().setInstructorDetail(null);
+        if (tempInstructorDetail != null && tempInstructorDetail.getInstructor() != null) {
+            tempInstructorDetail.getInstructor().setInstructorDetail(null);
+        }
 
         // delete the instructor detail
         if(tempInstructorDetail != null){

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -58,6 +58,12 @@ public class AppDAOImpl implements AppDAO{
         // retrieve the instructor detail
         InstructorDetail tempInstructorDetail = entityManager.find(InstructorDetail.class, theId);
 
+        // remove the associated object reference
+
+        // break bi-directional link
+
+        tempInstructorDetail.getInstructor().setInstructorDetail(null);
+
         // delete the instructor detail
         if(tempInstructorDetail != null){
             entityManager.remove(tempInstructorDetail);

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -2,6 +2,7 @@ package np.com.krishnabk.cruddemo.dao;
 
 import jakarta.persistence.EntityManager;
 import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +42,13 @@ public class AppDAOImpl implements AppDAO{
         if (tempInstructor != null) {
             entityManager.remove(tempInstructor);
         }
+    }
+
+    @Override
+    public InstructorDetail findInstructorDetailById(int theId) {
+
+        return entityManager.find(InstructorDetail.class, theId);
+
     }
 
 }

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -51,4 +51,17 @@ public class AppDAOImpl implements AppDAO{
 
     }
 
+    @Override
+    @Transactional
+    public void deleteInstructorDetailById(int theId) {
+
+        // retrieve the instructor detail
+        InstructorDetail tempInstructorDetail = entityManager.find(InstructorDetail.class, theId);
+
+        // delete the instructor detail
+        if(tempInstructorDetail != null){
+            entityManager.remove(tempInstructorDetail);
+        } else System.out.println("Instructor ID not found!");
+    }
+
 }

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
@@ -1,0 +1,99 @@
+    package np.com.krishnabk.cruddemo.entity;
+
+    import jakarta.persistence.*;
+
+    @Entity
+    @Table(name = "instructor")
+    public class Instructor {
+
+        // step 1. annotate the class as an entity and map to db table
+
+        // step 2. define table fields
+
+        // step 3. annotate the fields with db column names
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "id")
+        private int id;
+
+        @Column(name = "first_name")
+        private String firstName;
+
+        @Column(name = "last_name")
+        private String lastName;
+
+        @Column(name = "email")
+        private String email;
+
+        // set up mapping to InstructorDetail entity
+
+        @OneToOne(cascade = CascadeType.ALL)
+        @JoinColumn(name = "instructor_detail_id")
+        private InstructorDetail instructorDetail;
+
+        // step 4. create constructors
+
+        public Instructor(){}
+
+        public Instructor(String firstName, String lastName, String email) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.email = email;
+        }
+
+        // step 5. generate getters/setters methods
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public InstructorDetail getInstructorDetail() {
+            return instructorDetail;
+        }
+
+        public void setInstructorDetail(InstructorDetail instructorDetail) {
+            this.instructorDetail = instructorDetail;
+        }
+
+        // step 6. generate toString() method
+
+        @Override
+        public String toString() {
+            return "Instructor{" +
+                    "id=" + id +
+                    ", firstName='" + firstName + '\'' +
+                    ", lastName='" + lastName + '\'' +
+                    ", email='" + email + '\'' +
+                    ", instructorDetail=" + instructorDetail +
+                    '}';
+        }
+    }

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
@@ -22,7 +22,7 @@ public class InstructorDetail {
     private String hobby;
 
     // add @OneToOne annotation
-    @OneToOne(mappedBy = "instructorDetail", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "instructorDetail", cascade = {CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
     private Instructor instructor;
 
 

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
@@ -21,6 +21,11 @@ public class InstructorDetail {
     @Column(name = "hobby")
     private String hobby;
 
+    // add @OneToOne annotation
+    @OneToOne(mappedBy = "instructorDetail", cascade = CascadeType.ALL)
+    private Instructor instructor;
+
+
     // step 4. create constructors
     public InstructorDetail(){
 
@@ -55,6 +60,14 @@ public class InstructorDetail {
 
     public void setHobby(String hobby) {
         this.hobby = hobby;
+    }
+
+    public Instructor getInstructor() {
+        return instructor;
+    }
+
+    public void setInstructor(Instructor instructor) {
+        this.instructor = instructor;
     }
 
     // step 6. generate toString() method

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
@@ -1,0 +1,70 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "instructor_detail")
+public class InstructorDetail {
+
+
+    // step 1. annotate the class as an entity and map to db table
+    // step 2. define table fields
+    // step 3. annotate the fields with db column names
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "youtube_channel")
+    private String youtubeChannel;
+
+    @Column(name = "hobby")
+    private String hobby;
+
+    // step 4. create constructors
+    public InstructorDetail(){
+
+    }
+
+    public InstructorDetail(String youtubeChannel, String hobby) {
+        this.youtubeChannel = youtubeChannel;
+        this.hobby = hobby;
+    }
+
+    // step 5. generate getters/setters methods
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getYoutubeChannel() {
+        return youtubeChannel;
+    }
+
+    public void setYoutubeChannel(String youtubeChannel) {
+        this.youtubeChannel = youtubeChannel;
+    }
+
+    public String getHobby() {
+        return hobby;
+    }
+
+    public void setHobby(String hobby) {
+        this.hobby = hobby;
+    }
+
+    // step 6. generate toString() method
+
+    @Override
+    public String toString() {
+        return "InstructorDetail{" +
+                "id=" + id +
+                ", youtubeChannel='" + youtubeChannel + '\'' +
+                ", hobby='" + hobby + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/resources/application.properties
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+spring.application.name=02-jpa-one-to-one-bi
+spring.datasource.url=jdbc:mysql://localhost:3306/hb-01-one-to-one-uni
+spring.datasource.username=springstudent
+spring.datasource.password=springstudent
+
+# Turn off the Spring Boot Banner
+spring.main.banner-mode=off
+
+# Reduce logging level. Set logging level to warn
+logging.level.root=warn
+
+
+# Show JPA/Hibernate logging message
+logging.level.org.hibernate.sql=trace
+logging.level.org.hibernate.orm.jdbc.bind=trace

--- a/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/test/java/np/com/krishnabk/cruddemo/ApplicationTests.java
+++ b/09-spring-boot-jpa-advanced-mappings/02-jpa-one-to-one-bi/src/test/java/np/com/krishnabk/cruddemo/ApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.cruddemo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
### Summary
This PR introduces the initial structure and core features for the JPA One-to-One Bidirectional mapping module, extending the unidirectional example. It provides bidirectional entity mapping, CRUD operations, and proper cascade handling for safe deletions.

### Changes
- **Project Initialization:**
  - Added new module with starter files for entities, DAO, config, and tests.

- **Bidirectional Mapping:**
  - Enabled `@OneToOne` bidirectional mapping between `Instructor` and `InstructorDetail`.
  - Added `instructor` field and mappedBy annotation in `InstructorDetail`.

- **CRUD Operations:**
  - Added methods to the DAO for retrieving and deleting both entities by ID.
  - Implemented logic in `Application.java` to demonstrate finding and deleting `InstructorDetail` and its associated `Instructor`.

- **Cascade and Link Handling:**
  - Changed cascade type to `{DETACH, MERGE, PERSIST, REFRESH}` to prevent accidental deletes.
  - Explicitly broke bidirectional links before deletion to avoid constraint violations.