### PR TITLE
Add JPA One-to-Many Mapping: Course Entity, Bidirectional Relationship, and Demo

### DIFF
--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/.gitattributes
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/.gitignore
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>np.com.krishnabk</groupId>
+    <artifactId>cruddemo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>03-jpa-one-to-many</name>
+    <description>03-jpa-one-to-many</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,0 +1,102 @@
+package np.com.krishnabk.cruddemo;
+
+import np.com.krishnabk.cruddemo.dao.AppDAO;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    public CommandLineRunner commandLineRunner(AppDAO appDAO){
+
+        return runner -> {
+//            createInstructor(appDAO);
+//            findInstructor(appDAO);
+//            deleteInstructor(appDAO);
+//            findInstructorDetail(appDAO);
+            deleteInstructorDetail(appDAO);
+        };
+    }
+
+    private void deleteInstructorDetail(AppDAO appDAO) {
+
+        int theId = 3;
+        System.out.println("Deleting instructor id: " + theId);
+
+        appDAO.deleteInstructorDetailById(theId);
+
+        System.out.println("Done!");
+
+    }
+
+    private void findInstructorDetail(AppDAO appDAO) {
+
+        // get the instructor detail object
+        int theId = 1;
+        InstructorDetail tempInstructorDetail = appDAO.findInstructorDetailById(theId);
+
+        // print the instructor detail
+        System.out.println("tempInstructorDetail: " + tempInstructorDetail);
+
+        // print the associated instructor
+        System.out.println("The associated instructor: " + tempInstructorDetail.getInstructor());
+
+        System.out.println("Done!");
+    }
+
+    private void deleteInstructor(AppDAO appDAO) {
+
+        int theId = 1;
+        System.out.println("Deleting instructor id: " + theId);
+
+        appDAO.deleteInstructorById(theId);
+
+        System.out.println("Done!");
+    }
+
+    private void findInstructor(AppDAO appDAO) {
+        int theId = 1;
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor  = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        if (tempInstructor != null) {
+            System.out.println("the associated instructorDetail only: " + tempInstructor.getInstructorDetail());
+        } else {
+            System.out.println("Instructor not found with id: " + theId);
+        }
+    }
+
+    private void createInstructor(AppDAO appDAO) {
+
+        // create the instructor
+        Instructor tempInstructor = new Instructor(
+                "Krishna", "Bishowkarma", "hi@krishna-bk.com.np"
+        );
+
+        // create the instructor detail
+        InstructorDetail tempInstructorDetail = new InstructorDetail(
+                "https://www.youtube.com/@krishnabkarma","Filmmaking"
+        );
+
+        // associate the objects
+        tempInstructor.setInstructorDetail(tempInstructorDetail);
+
+        // save the objects
+        // NOTE: this will also save the details object because of CascadeType.ALL
+        System.out.println("Saving Instructor: " + tempInstructor);
+        appDAO.save(tempInstructor);
+        System.out.println("Done!");
+    }
+
+}

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,6 +1,7 @@
 package np.com.krishnabk.cruddemo;
 
 import np.com.krishnabk.cruddemo.dao.AppDAO;
+import np.com.krishnabk.cruddemo.entity.Course;
 import np.com.krishnabk.cruddemo.entity.Instructor;
 import np.com.krishnabk.cruddemo.entity.InstructorDetail;
 import org.springframework.boot.CommandLineRunner;
@@ -23,8 +24,36 @@ public class Application {
 //            findInstructor(appDAO);
 //            deleteInstructor(appDAO);
 //            findInstructorDetail(appDAO);
-            deleteInstructorDetail(appDAO);
+//            deleteInstructorDetail(appDAO);
+            createInstructorWithCourses(appDAO);
         };
+    }
+
+    private void createInstructorWithCourses(AppDAO appDAO) {
+
+        // create the instructor
+        Instructor tempInstructor =
+                new Instructor("Naresh", "Lohar", "naresh@krishna-bk.com.np");
+
+        // create the instructor detail
+        InstructorDetail tempInstructorDetail =
+                new InstructorDetail("https://www.youtube.com", "Music");
+
+        // create the courses
+        Course tempCourse1 = new Course("Air Guitar - The Ultimate Guide");
+        Course tempCourse2 = new Course("Basic of MUSIC");
+        Course tempCourse3 = new Course("The Pinball Masterclass");
+
+        // add courses to instructor
+        tempInstructor.add(tempCourse1);
+        tempInstructor.add(tempCourse2);
+        tempInstructor.add(tempCourse3);
+
+        // save the instructor
+        System.out.println("Saving instructor: " + tempInstructor);
+        System.out.println("The courses: " + tempInstructor.getCourses());
+        appDAO.save(tempInstructor);
+        System.out.println("DONE!");
     }
 
     private void deleteInstructorDetail(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -1,0 +1,17 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+
+public interface AppDAO {
+
+    void save(Instructor theInstructor);
+
+    Instructor findInstructorById(int theId);
+
+    void deleteInstructorById(int theId);
+
+    InstructorDetail findInstructorDetailById(int theId);
+
+    void deleteInstructorDetailById(int theId);
+}

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -1,0 +1,73 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import jakarta.persistence.EntityManager;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class AppDAOImpl implements AppDAO{
+
+    // define field for entity manager
+    private EntityManager entityManager;
+
+    // inject entity manager using constructor injection
+    @Autowired
+    public AppDAOImpl(EntityManager entityManager){
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    @Transactional
+    public void save(Instructor theInstructor) {
+        entityManager.persist(theInstructor);
+
+    }
+
+    @Override
+    public Instructor findInstructorById(int theId) {
+        return entityManager.find(Instructor.class, theId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteInstructorById(int theId) {
+
+        // retrieve the instructor
+        Instructor tempInstructor = entityManager.find(Instructor.class, theId);
+
+        // delete the instructor if found
+        if (tempInstructor != null) {
+            entityManager.remove(tempInstructor);
+        }
+    }
+
+    @Override
+    public InstructorDetail findInstructorDetailById(int theId) {
+
+        return entityManager.find(InstructorDetail.class, theId);
+
+    }
+
+    @Override
+    @Transactional
+    public void deleteInstructorDetailById(int theId) {
+
+        // retrieve the instructor detail
+        InstructorDetail tempInstructorDetail = entityManager.find(InstructorDetail.class, theId);
+
+        // remove the associated object reference
+
+        // break bi-directional link
+
+        tempInstructorDetail.getInstructor().setInstructorDetail(null);
+
+        // delete the instructor detail
+        if(tempInstructorDetail != null){
+            entityManager.remove(tempInstructorDetail);
+        } else System.out.println("Instructor ID not found!");
+    }
+
+}

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
@@ -8,7 +8,7 @@ public class Course {
 
     // define fields
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private int id;
 

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
@@ -1,0 +1,66 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "course")
+public class Course {
+
+    // define fields
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "title")
+    private String title;
+
+    @ManyToOne(cascade = {CascadeType.DETACH, CascadeType.MERGE,
+                            CascadeType.PERSIST, CascadeType.REFRESH})
+    @JoinColumn(name = "instructor_id")
+    private Instructor instructor;
+
+    // define constructors
+    public Course(){}
+
+    public Course(String title) {
+        this.title = title;
+    }
+
+    // define getters and setters
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Instructor getInstructor() {
+        return instructor;
+    }
+
+    public void setInstructor(Instructor instructor) {
+        this.instructor = instructor;
+    }
+
+
+    // define toString()
+
+    @Override
+    public String toString() {
+        return "Course{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
@@ -2,6 +2,9 @@
 
     import jakarta.persistence.*;
 
+    import java.util.ArrayList;
+    import java.util.List;
+
     @Entity
     @Table(name = "instructor")
     public class Instructor {
@@ -31,6 +34,11 @@
         @OneToOne(cascade = CascadeType.ALL)
         @JoinColumn(name = "instructor_detail_id")
         private InstructorDetail instructorDetail;
+
+        @OneToMany(mappedBy = "instructor",
+                    cascade = {CascadeType.DETACH, CascadeType.MERGE,
+                            CascadeType.PERSIST, CascadeType.REFRESH})
+        private List<Course> courses;
 
         // step 4. create constructors
 
@@ -84,6 +92,14 @@
             this.instructorDetail = instructorDetail;
         }
 
+        public List<Course> getCourses() {
+            return courses;
+        }
+
+        public void setCourses(List<Course> courses) {
+            this.courses = courses;
+        }
+
         // step 6. generate toString() method
 
         @Override
@@ -95,5 +111,17 @@
                     ", email='" + email + '\'' +
                     ", instructorDetail=" + instructorDetail +
                     '}';
+        }
+
+        // add convenience method for bidirectional relationship
+
+        public void add(Course tempCourse){
+            if (courses == null){
+                courses = new ArrayList<>();
+            }
+
+            courses.add(tempCourse);
+
+            tempCourse.setInstructor(this);
         }
     }

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
@@ -1,0 +1,99 @@
+    package np.com.krishnabk.cruddemo.entity;
+
+    import jakarta.persistence.*;
+
+    @Entity
+    @Table(name = "instructor")
+    public class Instructor {
+
+        // step 1. annotate the class as an entity and map to db table
+
+        // step 2. define table fields
+
+        // step 3. annotate the fields with db column names
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "id")
+        private int id;
+
+        @Column(name = "first_name")
+        private String firstName;
+
+        @Column(name = "last_name")
+        private String lastName;
+
+        @Column(name = "email")
+        private String email;
+
+        // set up mapping to InstructorDetail entity
+
+        @OneToOne(cascade = CascadeType.ALL)
+        @JoinColumn(name = "instructor_detail_id")
+        private InstructorDetail instructorDetail;
+
+        // step 4. create constructors
+
+        public Instructor(){}
+
+        public Instructor(String firstName, String lastName, String email) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.email = email;
+        }
+
+        // step 5. generate getters/setters methods
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public InstructorDetail getInstructorDetail() {
+            return instructorDetail;
+        }
+
+        public void setInstructorDetail(InstructorDetail instructorDetail) {
+            this.instructorDetail = instructorDetail;
+        }
+
+        // step 6. generate toString() method
+
+        @Override
+        public String toString() {
+            return "Instructor{" +
+                    "id=" + id +
+                    ", firstName='" + firstName + '\'' +
+                    ", lastName='" + lastName + '\'' +
+                    ", email='" + email + '\'' +
+                    ", instructorDetail=" + instructorDetail +
+                    '}';
+        }
+    }

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
@@ -1,0 +1,83 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "instructor_detail")
+public class InstructorDetail {
+
+
+    // step 1. annotate the class as an entity and map to db table
+    // step 2. define table fields
+    // step 3. annotate the fields with db column names
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "youtube_channel")
+    private String youtubeChannel;
+
+    @Column(name = "hobby")
+    private String hobby;
+
+    // add @OneToOne annotation
+    @OneToOne(mappedBy = "instructorDetail", cascade = {CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
+    private Instructor instructor;
+
+
+    // step 4. create constructors
+    public InstructorDetail(){
+
+    }
+
+    public InstructorDetail(String youtubeChannel, String hobby) {
+        this.youtubeChannel = youtubeChannel;
+        this.hobby = hobby;
+    }
+
+    // step 5. generate getters/setters methods
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getYoutubeChannel() {
+        return youtubeChannel;
+    }
+
+    public void setYoutubeChannel(String youtubeChannel) {
+        this.youtubeChannel = youtubeChannel;
+    }
+
+    public String getHobby() {
+        return hobby;
+    }
+
+    public void setHobby(String hobby) {
+        this.hobby = hobby;
+    }
+
+    public Instructor getInstructor() {
+        return instructor;
+    }
+
+    public void setInstructor(Instructor instructor) {
+        this.instructor = instructor;
+    }
+
+    // step 6. generate toString() method
+
+    @Override
+    public String toString() {
+        return "InstructorDetail{" +
+                "id=" + id +
+                ", youtubeChannel='" + youtubeChannel + '\'' +
+                ", hobby='" + hobby + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/resources/application.properties
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+spring.application.name=03-jpa-one-to-many
+spring.datasource.url=jdbc:mysql://localhost:3306/hb-03-one-to-many
+spring.datasource.username=springstudent
+spring.datasource.password=springstudent
+
+# Turn off the Spring Boot Banner
+spring.main.banner-mode=off
+
+# Reduce logging level. Set logging level to warn
+logging.level.root=warn
+
+
+# Show JPA/Hibernate logging message
+logging.level.org.hibernate.sql=trace
+logging.level.org.hibernate.orm.jdbc.bind=trace

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/test/java/np/com/krishnabk/cruddemo/ApplicationTests.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/test/java/np/com/krishnabk/cruddemo/ApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.cruddemo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
**PR Description:**  
This pull request introduces and demonstrates JPA one-to-many mapping between `Instructor` and `Course` entities. Key changes include:

- **Initialize one-to-many mapping module:**  
  - Added initial project files for the JPA one-to-many mapping example, based on the structure of the previous one-to-one module.
  - Included starter DAO, entities, configuration, and test files for future development.

- **Add `Course` entity and relationship:**  
  - Introduced the `Course` entity with `id` and `title` fields.
  - Configured `@ManyToOne` mapping from `Course` to `Instructor` with appropriate cascade options.
  - Provided constructors, getters/setters, and `toString` method.

- **Enhance `Instructor` entity:**  
  - Added a `courses` field to `Instructor` for the one-to-many relationship.
  - Implemented a convenience method for bidirectional mapping between `Instructor` and `Course`.

- **Demo method in `Application`:**  
  - Added a method to create an instructor with multiple courses as a demonstration of the one-to-many mapping.
  - Updated main runner to invoke this demonstration method.

- **Primary key generation fix:**  
  - Changed `@GeneratedValue` strategy from `AUTO` to `IDENTITY` for `Course` entity `id` to ensure proper PK generation.