### PR TITLE
feat(jpa-one-to-many): enhance instructor-course querying and association logic

### DIFF
--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -25,8 +25,22 @@ public class Application {
 //            deleteInstructor(appDAO);
 //            findInstructorDetail(appDAO);
 //            deleteInstructorDetail(appDAO);
-            createInstructorWithCourses(appDAO);
+//            createInstructorWithCourses(appDAO);
+            findInstructorWithCourses(appDAO);
         };
+    }
+
+    private void findInstructorWithCourses(AppDAO appDAO) {
+
+        int theId = 2;
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        System.out.println("the associated courses: " + tempInstructor.getCourses());
+
+        System.out.println("DONE!");
     }
 
     private void createInstructorWithCourses(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -9,6 +9,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
+import java.util.List;
+
 @SpringBootApplication
 public class Application {
 
@@ -26,8 +28,31 @@ public class Application {
 //            findInstructorDetail(appDAO);
 //            deleteInstructorDetail(appDAO);
 //            createInstructorWithCourses(appDAO);
-            findInstructorWithCourses(appDAO);
+//            findInstructorWithCourses(appDAO);
+            findCoursesForInstructor(appDAO);
         };
+    }
+
+    private void findCoursesForInstructor(AppDAO appDAO) {
+
+        int theId = 2;
+
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+
+        // find courses for instructor
+        System.out.println("Finding courses for instructor id: " + theId);
+        List<Course> courses = appDAO.findCoursesByInstructor(theId);
+
+        // associate the objects
+        tempInstructor.setCourses(courses);
+
+        System.out.println("The associated courses: " + tempInstructor.getCourses());
+
+        System.out.println("DONE!");
     }
 
     private void findInstructorWithCourses(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -1,7 +1,10 @@
 package np.com.krishnabk.cruddemo.dao;
 
+import np.com.krishnabk.cruddemo.entity.Course;
 import np.com.krishnabk.cruddemo.entity.Instructor;
 import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+
+import java.util.List;
 
 public interface AppDAO {
 
@@ -14,4 +17,6 @@ public interface AppDAO {
     InstructorDetail findInstructorDetailById(int theId);
 
     void deleteInstructorDetailById(int theId);
+
+    List<Course> findCoursesByInstructor(int theId);
 }

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -1,11 +1,15 @@
 package np.com.krishnabk.cruddemo.dao;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import np.com.krishnabk.cruddemo.entity.Course;
 import np.com.krishnabk.cruddemo.entity.Instructor;
 import np.com.krishnabk.cruddemo.entity.InstructorDetail;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Repository
 public class AppDAOImpl implements AppDAO{
@@ -68,6 +72,21 @@ public class AppDAOImpl implements AppDAO{
         if(tempInstructorDetail != null){
             entityManager.remove(tempInstructorDetail);
         } else System.out.println("Instructor ID not found!");
+    }
+
+    @Override
+    public List<Course> findCoursesByInstructor(int theId) {
+
+        // create query
+        TypedQuery<Course> query = entityManager.createQuery(
+                "from Course where instructor.id = :data", Course.class);
+
+        query.setParameter("data", theId);
+
+        // execute the query
+        List<Course> courses = query.getResultList();
+
+        return courses;
     }
 
 }

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
@@ -36,7 +36,7 @@
         private InstructorDetail instructorDetail;
 
         @OneToMany(mappedBy = "instructor",
-                    fetch = FetchType.EAGER,
+                    fetch = FetchType.LAZY,
                     cascade = {CascadeType.DETACH, CascadeType.MERGE,
                             CascadeType.PERSIST, CascadeType.REFRESH})
         private List<Course> courses;

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
@@ -36,6 +36,7 @@
         private InstructorDetail instructorDetail;
 
         @OneToMany(mappedBy = "instructor",
+                    fetch = FetchType.EAGER,
                     cascade = {CascadeType.DETACH, CascadeType.MERGE,
                             CascadeType.PERSIST, CascadeType.REFRESH})
         private List<Course> courses;


### PR DESCRIPTION
This PR introduces improvements to the one-to-many relationship between `Instructor` and `Course` entities in the Spring Boot JPA module:

- Adds `findCoursesByInstructor` method to `AppDAO` and `AppDAOImpl`, enabling retrieval of courses for a given instructor ID with a JPQL query.
- Refactors `@OneToMany` mapping in `Instructor` entity from `FetchType.EAGER` to `FetchType.LAZY` for optimized, on-demand loading.
- Implements `findCoursesForInstructor` in `Application.java` to demonstrate explicit querying and association of courses with an instructor.
- Updates code to print instructor and associated courses as part of the demonstration.
- Comments out previous eager loading logic in favor of explicit DAO-driven querying and association.

**Why?**  
These changes improve flexibility and performance by allowing for more control over when courses are loaded and how they're associated with instructors, following best practices for JPA one-to-many relationships.