### PR TITLE
feat(jpa-one-to-many): add optimized instructor and courses retrieval using join fetch

### DIFF
--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -29,8 +29,22 @@ public class Application {
 //            deleteInstructorDetail(appDAO);
 //            createInstructorWithCourses(appDAO);
 //            findInstructorWithCourses(appDAO);
-            findCoursesForInstructor(appDAO);
+//            findCoursesForInstructor(appDAO);
+            findInstructorWithCoursesJoinFetch(appDAO);
         };
+    }
+
+    private void findInstructorWithCoursesJoinFetch(AppDAO appDAO) {
+        int theId = 2;
+
+        // find the instructor
+        System.out.println("Finding instructor id: " + theId);
+        Instructor tempInstructor = appDAO.findInstructorByIdJoinFetch(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        System.out.println("the associated courses: " + tempInstructor.getCourses());
+
+        System.out.println("DONE!");
     }
 
     private void findCoursesForInstructor(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -19,4 +19,6 @@ public interface AppDAO {
     void deleteInstructorDetailById(int theId);
 
     List<Course> findCoursesByInstructor(int theId);
+
+    Instructor findInstructorByIdJoinFetch(int theId);
 }

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -89,4 +89,22 @@ public class AppDAOImpl implements AppDAO{
         return courses;
     }
 
+    @Override
+    public Instructor findInstructorByIdJoinFetch(int theId) {
+
+        // create query
+        TypedQuery<Instructor> query =  entityManager.createQuery(
+                "select i from Instructor  i "
+                + "JOIN  FETCH i.courses "
+                + "where i.id = :data", Instructor.class);
+
+        query.setParameter("data", theId);
+
+        // execute query
+        Instructor instructor = query.getSingleResult();
+
+        return instructor;
+
+    }
+
 }


### PR DESCRIPTION
- Add findInstructorByIdJoinFetch method to AppDAO and AppDAOImpl for fetching instructor and associated courses using JPQL JOIN FETCH
- Implement findInstructorWithCoursesJoinFetch in Application.java to demonstrate eager loading via join fetch
- Comment out previous explicit course query and association logic in favor of optimized join fetch approach