### PR TITLE
feat: support instructor deletion with course association and add course deletion functionality

### DIFF
--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -24,7 +24,7 @@ public class Application {
         return runner -> {
 //            createInstructor(appDAO);
 //            findInstructor(appDAO);
-//            deleteInstructor(appDAO);
+            deleteInstructor(appDAO);
 //            findInstructorDetail(appDAO);
 //            deleteInstructorDetail(appDAO);
 //            createInstructorWithCourses(appDAO);
@@ -32,7 +32,7 @@ public class Application {
 //            findCoursesForInstructor(appDAO);
 //            findInstructorWithCoursesJoinFetch(appDAO);
 //            updateInstructor(appDAO);
-            updateCourse(appDAO);
+//            updateCourse(appDAO);
         };
     }
 
@@ -172,7 +172,7 @@ public class Application {
 
     private void deleteInstructor(AppDAO appDAO) {
 
-        int theId = 1;
+        int theId = 2;
         System.out.println("Deleting instructor id: " + theId);
 
         appDAO.deleteInstructorById(theId);

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -24,7 +24,7 @@ public class Application {
         return runner -> {
 //            createInstructor(appDAO);
 //            findInstructor(appDAO);
-            deleteInstructor(appDAO);
+//            deleteInstructor(appDAO);
 //            findInstructorDetail(appDAO);
 //            deleteInstructorDetail(appDAO);
 //            createInstructorWithCourses(appDAO);
@@ -33,7 +33,19 @@ public class Application {
 //            findInstructorWithCoursesJoinFetch(appDAO);
 //            updateInstructor(appDAO);
 //            updateCourse(appDAO);
+            deleteCourse(appDAO);
         };
+    }
+
+    private void deleteCourse(AppDAO appDAO) {
+
+        int theId = 10;
+
+        System.out.println("Deleting course id: " + theId);
+
+        appDAO.deleteCourseById(theId);
+
+        System.out.println("DONE!");
     }
 
     private void updateCourse(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -27,4 +27,6 @@ public interface AppDAO {
     void update(Course tempCourse);
 
     Course findCourseById(int theId);
+
+    void deleteCourseById(int theId);
 }

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -42,10 +42,16 @@ public class AppDAOImpl implements AppDAO{
         // retrieve the instructor
         Instructor tempInstructor = entityManager.find(Instructor.class, theId);
 
-        // delete the instructor if found
-        if (tempInstructor != null) {
-            entityManager.remove(tempInstructor);
+        // get the courses
+        List<Course> courses = tempInstructor.getCourses();
+
+        // break association of all courses for the instructor
+        for(Course tempCourse : courses){
+            tempCourse.setInstructor(null);
         }
+
+        // delete the instructor if found
+        entityManager.remove(tempInstructor);
     }
 
     @Override

--- a/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/03-jpa-one-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -129,4 +129,16 @@ public class AppDAOImpl implements AppDAO{
     public Course findCourseById(int theId) {
         return entityManager.find(Course.class, theId);
     }
+
+    @Override
+    @Transactional
+    public void deleteCourseById(int theId) {
+
+        // retrieve the course
+        Course tempCourse = entityManager.find(Course.class, theId);
+
+        // delete the course
+        entityManager.remove(tempCourse);
+
+    }
 }


### PR DESCRIPTION
This pull request introduces the following enhancements:

- **Instructor Deletion Handling:**  
  - When deleting an instructor, the `instructor` field of all associated courses is set to `null`.  
  - This ensures courses remain in the database, breaking the relationship before instructor removal.
  - The application runner now demonstrates deleting an instructor by id.

- **Course Deletion:**  
  - Added `deleteCourseById(int theId)` method to both AppDAO and AppDAOImpl.
  - Added trigger in Application.java to delete a course.
  - Commented out instructor deletion logic to validate course deletion.