### PR TITLE
feat: implement uni-directional one-to-many mapping between Course and Review

### DIFF
--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/.gitattributes
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/.gitignore
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>np.com.krishnabk</groupId>
+    <artifactId>cruddemo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>04-jpa-one-to-many-uni</name>
+    <description>04-jpa-one-to-many-uni</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,0 +1,220 @@
+package np.com.krishnabk.cruddemo;
+
+import np.com.krishnabk.cruddemo.dao.AppDAO;
+import np.com.krishnabk.cruddemo.entity.Course;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.util.List;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    public CommandLineRunner commandLineRunner(AppDAO appDAO){
+
+        return runner -> {
+
+        };
+    }
+
+    private void deleteCourse(AppDAO appDAO) {
+
+        int theId = 10;
+
+        System.out.println("Deleting course id: " + theId);
+
+        appDAO.deleteCourseById(theId);
+
+        System.out.println("DONE!");
+    }
+
+    private void updateCourse(AppDAO appDAO) {
+
+        int theId = 10;
+
+        // find the course
+        System.out.println("Finding the course id: " + theId);
+        Course tempCourse = appDAO.findCourseById(theId);
+
+        // update the course
+        System.out.println("Updating course id: " + theId);
+        tempCourse.setTitle("Enjoy the Simple Things");
+
+        appDAO.update(tempCourse);
+
+        System.out.println("DONE!");
+    }
+
+    private void updateInstructor(AppDAO appDAO) {
+        int theId = 2;
+
+        // find the instructor
+        System.out.println("Finding instructor: " + theId);
+        Instructor tempInstructor = appDAO.findInstructorById(theId);
+
+        // update the instructor
+        System.out.println("Updating instructor id: " + theId);
+        tempInstructor.setLastName("B.K");
+
+        appDAO.update(tempInstructor);
+
+        System.out.println("DONE!");
+    }
+
+    private void findInstructorWithCoursesJoinFetch(AppDAO appDAO) {
+        int theId = 2;
+
+        // find the instructor
+        System.out.println("Finding instructor id: " + theId);
+        Instructor tempInstructor = appDAO.findInstructorByIdJoinFetch(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        System.out.println("the associated courses: " + tempInstructor.getCourses());
+
+        System.out.println("DONE!");
+    }
+
+    private void findCoursesForInstructor(AppDAO appDAO) {
+
+        int theId = 2;
+
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+
+        // find courses for instructor
+        System.out.println("Finding courses for instructor id: " + theId);
+        List<Course> courses = appDAO.findCoursesByInstructor(theId);
+
+        // associate the objects
+        tempInstructor.setCourses(courses);
+
+        System.out.println("The associated courses: " + tempInstructor.getCourses());
+
+        System.out.println("DONE!");
+    }
+
+    private void findInstructorWithCourses(AppDAO appDAO) {
+
+        int theId = 2;
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        System.out.println("the associated courses: " + tempInstructor.getCourses());
+
+        System.out.println("DONE!");
+    }
+
+    private void createInstructorWithCourses(AppDAO appDAO) {
+
+        // create the instructor
+        Instructor tempInstructor =
+                new Instructor("Naresh", "Lohar", "naresh@krishna-bk.com.np");
+
+        // create the instructor detail
+        InstructorDetail tempInstructorDetail =
+                new InstructorDetail("https://www.youtube.com", "Music");
+
+        // create the courses
+        Course tempCourse1 = new Course("Air Guitar - The Ultimate Guide");
+        Course tempCourse2 = new Course("Basic of MUSIC");
+        Course tempCourse3 = new Course("The Pinball Masterclass");
+
+        // add courses to instructor
+        tempInstructor.add(tempCourse1);
+        tempInstructor.add(tempCourse2);
+        tempInstructor.add(tempCourse3);
+
+        // save the instructor
+        System.out.println("Saving instructor: " + tempInstructor);
+        System.out.println("The courses: " + tempInstructor.getCourses());
+        appDAO.save(tempInstructor);
+        System.out.println("DONE!");
+    }
+
+    private void deleteInstructorDetail(AppDAO appDAO) {
+
+        int theId = 3;
+        System.out.println("Deleting instructor id: " + theId);
+
+        appDAO.deleteInstructorDetailById(theId);
+
+        System.out.println("Done!");
+
+    }
+
+    private void findInstructorDetail(AppDAO appDAO) {
+
+        // get the instructor detail object
+        int theId = 1;
+        InstructorDetail tempInstructorDetail = appDAO.findInstructorDetailById(theId);
+
+        // print the instructor detail
+        System.out.println("tempInstructorDetail: " + tempInstructorDetail);
+
+        // print the associated instructor
+        System.out.println("The associated instructor: " + tempInstructorDetail.getInstructor());
+
+        System.out.println("Done!");
+    }
+
+    private void deleteInstructor(AppDAO appDAO) {
+
+        int theId = 2;
+        System.out.println("Deleting instructor id: " + theId);
+
+        appDAO.deleteInstructorById(theId);
+
+        System.out.println("Done!");
+    }
+
+    private void findInstructor(AppDAO appDAO) {
+        int theId = 1;
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor  = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        if (tempInstructor != null) {
+            System.out.println("the associated instructorDetail only: " + tempInstructor.getInstructorDetail());
+        } else {
+            System.out.println("Instructor not found with id: " + theId);
+        }
+    }
+
+    private void createInstructor(AppDAO appDAO) {
+
+        // create the instructor
+        Instructor tempInstructor = new Instructor(
+                "Krishna", "Bishowkarma", "hi@krishna-bk.com.np"
+        );
+
+        // create the instructor detail
+        InstructorDetail tempInstructorDetail = new InstructorDetail(
+                "https://www.youtube.com/@krishnabkarma","Filmmaking"
+        );
+
+        // associate the objects
+        tempInstructor.setInstructorDetail(tempInstructorDetail);
+
+        // save the objects
+        // NOTE: this will also save the details object because of CascadeType.ALL
+        System.out.println("Saving Instructor: " + tempInstructor);
+        appDAO.save(tempInstructor);
+        System.out.println("Done!");
+    }
+
+}

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -4,6 +4,7 @@ import np.com.krishnabk.cruddemo.dao.AppDAO;
 import np.com.krishnabk.cruddemo.entity.Course;
 import np.com.krishnabk.cruddemo.entity.Instructor;
 import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+import np.com.krishnabk.cruddemo.entity.Review;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -23,7 +24,30 @@ public class Application {
 
         return runner -> {
 
+            createCourseAndReviews(appDAO);
+
         };
+    }
+
+    private void createCourseAndReviews(AppDAO appDAO) {
+
+        // create a course
+        Course tempCourse = new Course("Pacman - How to score One Million Points");
+
+        // add some reviews
+        tempCourse.addReview(new Review("Great Course - Loved it!"));
+        tempCourse.addReview(new Review("Cool course, job well done."));
+        tempCourse.addReview(new Review("What a dumb course, you are an idiot!"));
+
+        // save the course ... and leverage the cascade all
+        System.out.println("Saving the course");
+        System.out.println("tempCourse");
+        System.out.println(tempCourse.getReviews());
+
+
+        appDAO.save(tempCourse);
+
+        System.out.println("DONE!");
     }
 
     private void deleteCourse(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -1,0 +1,32 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import np.com.krishnabk.cruddemo.entity.Course;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+
+import java.util.List;
+
+public interface AppDAO {
+
+    void save(Instructor theInstructor);
+
+    Instructor findInstructorById(int theId);
+
+    void deleteInstructorById(int theId);
+
+    InstructorDetail findInstructorDetailById(int theId);
+
+    void deleteInstructorDetailById(int theId);
+
+    List<Course> findCoursesByInstructor(int theId);
+
+    Instructor findInstructorByIdJoinFetch(int theId);
+
+    void update(Instructor tempInstructor);
+
+    void update(Course tempCourse);
+
+    Course findCourseById(int theId);
+
+    void deleteCourseById(int theId);
+}

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -29,4 +29,6 @@ public interface AppDAO {
     Course findCourseById(int theId);
 
     void deleteCourseById(int theId);
+
+    void save(Course theCourse);
 }

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -1,0 +1,144 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import np.com.krishnabk.cruddemo.entity.Course;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+public class AppDAOImpl implements AppDAO{
+
+    // define field for entity manager
+    private EntityManager entityManager;
+
+    // inject entity manager using constructor injection
+    @Autowired
+    public AppDAOImpl(EntityManager entityManager){
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    @Transactional
+    public void save(Instructor theInstructor) {
+        entityManager.persist(theInstructor);
+
+    }
+
+    @Override
+    public Instructor findInstructorById(int theId) {
+        return entityManager.find(Instructor.class, theId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteInstructorById(int theId) {
+
+        // retrieve the instructor
+        Instructor tempInstructor = entityManager.find(Instructor.class, theId);
+
+        // get the courses
+        List<Course> courses = tempInstructor.getCourses();
+
+        // break association of all courses for the instructor
+        for(Course tempCourse : courses){
+            tempCourse.setInstructor(null);
+        }
+
+        // delete the instructor if found
+        entityManager.remove(tempInstructor);
+    }
+
+    @Override
+    public InstructorDetail findInstructorDetailById(int theId) {
+
+        return entityManager.find(InstructorDetail.class, theId);
+
+    }
+
+    @Override
+    @Transactional
+    public void deleteInstructorDetailById(int theId) {
+
+        // retrieve the instructor detail
+        InstructorDetail tempInstructorDetail = entityManager.find(InstructorDetail.class, theId);
+
+        // remove the associated object reference
+
+        // break bi-directional link
+
+        tempInstructorDetail.getInstructor().setInstructorDetail(null);
+
+        // delete the instructor detail
+        if(tempInstructorDetail != null){
+            entityManager.remove(tempInstructorDetail);
+        } else System.out.println("Instructor ID not found!");
+    }
+
+    @Override
+    public List<Course> findCoursesByInstructor(int theId) {
+
+        // create query
+        TypedQuery<Course> query = entityManager.createQuery(
+                "from Course where instructor.id = :data", Course.class);
+
+        query.setParameter("data", theId);
+
+        // execute the query
+        List<Course> courses = query.getResultList();
+
+        return courses;
+    }
+
+    @Override
+    public Instructor findInstructorByIdJoinFetch(int theId) {
+
+        // create query
+        TypedQuery<Instructor> query =  entityManager.createQuery(
+                "select i from Instructor  i "
+                + "JOIN  FETCH i.courses "
+                + "where i.id = :data", Instructor.class);
+
+        query.setParameter("data", theId);
+
+        // execute query
+        Instructor instructor = query.getSingleResult();
+
+        return instructor;
+
+    }
+
+    @Override
+    @Transactional
+    public void update(Instructor tempInstructor) {
+        entityManager.merge(tempInstructor);
+    }
+
+    @Override
+    @Transactional
+    public void update(Course tempCourse) {
+        entityManager.merge(tempCourse);
+    }
+
+    @Override
+    public Course findCourseById(int theId) {
+        return entityManager.find(Course.class, theId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCourseById(int theId) {
+
+        // retrieve the course
+        Course tempCourse = entityManager.find(Course.class, theId);
+
+        // delete the course
+        entityManager.remove(tempCourse);
+
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -141,4 +141,11 @@ public class AppDAOImpl implements AppDAO{
         entityManager.remove(tempCourse);
 
     }
+
+    @Override
+    @Transactional
+    public void save(Course theCourse) {
+
+        entityManager.persist(theCourse);
+    }
 }

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
@@ -2,6 +2,9 @@ package np.com.krishnabk.cruddemo.entity;
 
 import jakarta.persistence.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "course")
 public class Course {
@@ -19,6 +22,10 @@ public class Course {
                             CascadeType.PERSIST, CascadeType.REFRESH})
     @JoinColumn(name = "instructor_id")
     private Instructor instructor;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "course_id")
+    private List<Review> reviews;
 
     // define constructors
     public Course(){}
@@ -53,6 +60,24 @@ public class Course {
         this.instructor = instructor;
     }
 
+    public List<Review> getReviews() {
+        return reviews;
+    }
+
+    public void setReviews(List<Review> reviews) {
+        this.reviews = reviews;
+    }
+
+    // add convenience method
+
+    public void addReview(Review theReview){
+
+        if(reviews == null){
+            reviews = new ArrayList<>();
+        }
+
+        reviews.add(theReview);
+    }
 
     // define toString()
 

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
@@ -1,0 +1,66 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "course")
+public class Course {
+
+    // define fields
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "title")
+    private String title;
+
+    @ManyToOne(cascade = {CascadeType.DETACH, CascadeType.MERGE,
+                            CascadeType.PERSIST, CascadeType.REFRESH})
+    @JoinColumn(name = "instructor_id")
+    private Instructor instructor;
+
+    // define constructors
+    public Course(){}
+
+    public Course(String title) {
+        this.title = title;
+    }
+
+    // define getters and setters
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Instructor getInstructor() {
+        return instructor;
+    }
+
+    public void setInstructor(Instructor instructor) {
+        this.instructor = instructor;
+    }
+
+
+    // define toString()
+
+    @Override
+    public String toString() {
+        return "Course{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
@@ -1,0 +1,128 @@
+    package np.com.krishnabk.cruddemo.entity;
+
+    import jakarta.persistence.*;
+
+    import java.util.ArrayList;
+    import java.util.List;
+
+    @Entity
+    @Table(name = "instructor")
+    public class Instructor {
+
+        // step 1. annotate the class as an entity and map to db table
+
+        // step 2. define table fields
+
+        // step 3. annotate the fields with db column names
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "id")
+        private int id;
+
+        @Column(name = "first_name")
+        private String firstName;
+
+        @Column(name = "last_name")
+        private String lastName;
+
+        @Column(name = "email")
+        private String email;
+
+        // set up mapping to InstructorDetail entity
+
+        @OneToOne(cascade = CascadeType.ALL)
+        @JoinColumn(name = "instructor_detail_id")
+        private InstructorDetail instructorDetail;
+
+        @OneToMany(mappedBy = "instructor",
+                    fetch = FetchType.LAZY,
+                    cascade = {CascadeType.DETACH, CascadeType.MERGE,
+                            CascadeType.PERSIST, CascadeType.REFRESH})
+        private List<Course> courses;
+
+        // step 4. create constructors
+
+        public Instructor(){}
+
+        public Instructor(String firstName, String lastName, String email) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.email = email;
+        }
+
+        // step 5. generate getters/setters methods
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public InstructorDetail getInstructorDetail() {
+            return instructorDetail;
+        }
+
+        public void setInstructorDetail(InstructorDetail instructorDetail) {
+            this.instructorDetail = instructorDetail;
+        }
+
+        public List<Course> getCourses() {
+            return courses;
+        }
+
+        public void setCourses(List<Course> courses) {
+            this.courses = courses;
+        }
+
+        // step 6. generate toString() method
+
+        @Override
+        public String toString() {
+            return "Instructor{" +
+                    "id=" + id +
+                    ", firstName='" + firstName + '\'' +
+                    ", lastName='" + lastName + '\'' +
+                    ", email='" + email + '\'' +
+                    ", instructorDetail=" + instructorDetail +
+                    '}';
+        }
+
+        // add convenience method for bidirectional relationship
+
+        public void add(Course tempCourse){
+            if (courses == null){
+                courses = new ArrayList<>();
+            }
+
+            courses.add(tempCourse);
+
+            tempCourse.setInstructor(this);
+        }
+    }

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
@@ -1,0 +1,83 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "instructor_detail")
+public class InstructorDetail {
+
+
+    // step 1. annotate the class as an entity and map to db table
+    // step 2. define table fields
+    // step 3. annotate the fields with db column names
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "youtube_channel")
+    private String youtubeChannel;
+
+    @Column(name = "hobby")
+    private String hobby;
+
+    // add @OneToOne annotation
+    @OneToOne(mappedBy = "instructorDetail", cascade = {CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
+    private Instructor instructor;
+
+
+    // step 4. create constructors
+    public InstructorDetail(){
+
+    }
+
+    public InstructorDetail(String youtubeChannel, String hobby) {
+        this.youtubeChannel = youtubeChannel;
+        this.hobby = hobby;
+    }
+
+    // step 5. generate getters/setters methods
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getYoutubeChannel() {
+        return youtubeChannel;
+    }
+
+    public void setYoutubeChannel(String youtubeChannel) {
+        this.youtubeChannel = youtubeChannel;
+    }
+
+    public String getHobby() {
+        return hobby;
+    }
+
+    public void setHobby(String hobby) {
+        this.hobby = hobby;
+    }
+
+    public Instructor getInstructor() {
+        return instructor;
+    }
+
+    public void setInstructor(Instructor instructor) {
+        this.instructor = instructor;
+    }
+
+    // step 6. generate toString() method
+
+    @Override
+    public String toString() {
+        return "InstructorDetail{" +
+                "id=" + id +
+                ", youtubeChannel='" + youtubeChannel + '\'' +
+                ", hobby='" + hobby + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/entity/Review.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/java/np/com/krishnabk/cruddemo/entity/Review.java
@@ -1,0 +1,52 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "review")
+public class Review {
+
+    // define fields
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "comment")
+    private String comment;
+
+    // define constructors
+    public Review(){}
+
+    public Review(String comment) {
+        this.comment = comment;
+    }
+
+    // define getters/setters
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    // define toString
+
+    @Override
+    public String toString() {
+        return "Review{" +
+                "id=" + id +
+                ", comment='" + comment + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/resources/application.properties
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+spring.application.name=04-jpa-one-to-many-uni
+spring.datasource.url=jdbc:mysql://localhost:3306/hb-04-one-to-many-uni
+spring.datasource.username=springstudent
+spring.datasource.password=springstudent
+
+# Turn off the Spring Boot Banner
+spring.main.banner-mode=off
+
+# Reduce logging level. Set logging level to warn
+logging.level.root=warn
+
+
+# Show JPA/Hibernate logging message
+logging.level.org.hibernate.sql=trace
+logging.level.org.hibernate.orm.jdbc.bind=trace

--- a/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/test/java/np/com/krishnabk/cruddemo/ApplicationTests.java
+++ b/09-spring-boot-jpa-advanced-mappings/04-jpa-one-to-many-uni/src/test/java/np/com/krishnabk/cruddemo/ApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.cruddemo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION
This pull request introduces the following changes for the `04-jpa-one-to-many-uni` section:

- **Project Structure:**  
  - Copied the base structure from `03-jpa-one-to-many` to serve as a starting point for uni-directional mapping.

- **Review Entity:**  
  - Added `Review` entity with JPA annotations, fields for `id` and `comment`, and standard methods.

- **Course Entity Enhancements:**  
  - Added a uni-directional `@OneToMany` relationship from `Course` to `Review`.
  - Configured join column as `course_id` in the `review` table.
  - Added getter, setter, and a convenience method for adding reviews.

- **DAO Updates:**  
  - Introduced `save(Course theCourse)` method in both `AppDAO` and `AppDAOImpl` to persist courses with reviews.

- **Application Logic:**  
  - Added `createCourseAndReviews` method in `Application.java` to demonstrate creating a course with multiple reviews and saving them using cascade operations.

These updates set up the foundation for exploring uni-directional one-to-many relationships in JPA using Spring Boot.