### PR TITLE
feat(jpa): implement many-to-many between Course and Student with DAO methods

### DIFF
--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/.gitattributes
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/.gitignore
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/pom.xml
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>np.com.krishnabk</groupId>
+    <artifactId>cruddemo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>05-jpa-many-to-many</name>
+    <description>05-jpa-many-to-many</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -22,8 +22,31 @@ public class Application {
         return runner -> {
             //  createCourseAndStudents(appDAO);
             // findCourseAndStudents(appDAO);
-            findStudentAndCourses(appDAO);
+            // findStudentAndCourses(appDAO);
+
+            addMoreCoursesForStudents(appDAO);
         };
+    }
+
+    private void addMoreCoursesForStudents(AppDAO appDAO) {
+
+        int theId = 2;
+        Student tempStudent = appDAO.findStudentAndCourseByStudentId(theId);
+
+        // create more courses
+        Course tempCourse1 = new Course("FullStack Java Developer Path");
+        Course tempCourse2 = new Course("Game Development");
+
+        // add courses to students
+        tempStudent.addCourse(tempCourse1);
+        tempStudent.addCourse(tempCourse2);
+
+        System.out.println("Updating student: " + tempStudent);
+        System.out.println("associated courses: " + tempStudent.getCourses());
+
+        appDAO.update(tempStudent);
+
+        System.out.println("DONE!");
     }
 
     private void findStudentAndCourses(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -26,8 +26,21 @@ public class Application {
 
             // addMoreCoursesForStudents(appDAO);
 
-            deleteCourse(appDAO);
+            // deleteCourse(appDAO);
+
+            deleteStudent(appDAO);
         };
+    }
+
+    private void deleteStudent(AppDAO appDAO) {
+
+        int theId = 1;
+        System.out.println("Deleting student id: " + theId);
+
+        appDAO.deleteStudentById(theId);
+
+        System.out.println("DONE!");
+
     }
 
     private void addMoreCoursesForStudents(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,0 +1,268 @@
+package np.com.krishnabk.cruddemo;
+
+import np.com.krishnabk.cruddemo.dao.AppDAO;
+import np.com.krishnabk.cruddemo.entity.Course;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+import np.com.krishnabk.cruddemo.entity.Review;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.util.List;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    public CommandLineRunner commandLineRunner(AppDAO appDAO){
+
+        return runner -> {
+
+        };
+    }
+
+    private void deleteCourseAndReviews(AppDAO appDAO) {
+
+        int theId = 10;
+
+        System.out.println("Deleting course id: " + theId);
+
+        appDAO.deleteCourseById(theId);
+
+        System.out.println("DONE!");
+    }
+
+    private void retrieveCourseAndReviews(AppDAO appDAO) {
+
+        // get the course and reviews
+        int theId = 10;
+        Course tempCourse = appDAO.findCourseAndReviewByCourseId(theId);
+
+        // print the course
+        System.out.println(tempCourse);
+
+        // print the reviews
+        System.out.println(tempCourse.getReviews());
+
+        System.out.println("DONE!");
+    }
+
+    private void createCourseAndReviews(AppDAO appDAO) {
+
+        // create a course
+        Course tempCourse = new Course("Pacman - How to score One Million Points");
+
+        // add some reviews
+        tempCourse.addReview(new Review("Great Course - Loved it!"));
+        tempCourse.addReview(new Review("Cool course, job well done."));
+        tempCourse.addReview(new Review("What a dumb course, you are an idiot!"));
+
+        // save the course ... and leverage the cascade all
+        System.out.println("Saving the course");
+        System.out.println("tempCourse");
+        System.out.println(tempCourse.getReviews());
+
+
+        appDAO.save(tempCourse);
+
+        System.out.println("DONE!");
+    }
+
+    private void deleteCourse(AppDAO appDAO) {
+
+        int theId = 10;
+
+        System.out.println("Deleting course id: " + theId);
+
+        appDAO.deleteCourseById(theId);
+
+        System.out.println("DONE!");
+    }
+
+    private void updateCourse(AppDAO appDAO) {
+
+        int theId = 10;
+
+        // find the course
+        System.out.println("Finding the course id: " + theId);
+        Course tempCourse = appDAO.findCourseById(theId);
+
+        // update the course
+        System.out.println("Updating course id: " + theId);
+        tempCourse.setTitle("Enjoy the Simple Things");
+
+        appDAO.update(tempCourse);
+
+        System.out.println("DONE!");
+    }
+
+    private void updateInstructor(AppDAO appDAO) {
+        int theId = 2;
+
+        // find the instructor
+        System.out.println("Finding instructor: " + theId);
+        Instructor tempInstructor = appDAO.findInstructorById(theId);
+
+        // update the instructor
+        System.out.println("Updating instructor id: " + theId);
+        tempInstructor.setLastName("B.K");
+
+        appDAO.update(tempInstructor);
+
+        System.out.println("DONE!");
+    }
+
+    private void findInstructorWithCoursesJoinFetch(AppDAO appDAO) {
+        int theId = 2;
+
+        // find the instructor
+        System.out.println("Finding instructor id: " + theId);
+        Instructor tempInstructor = appDAO.findInstructorByIdJoinFetch(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        System.out.println("the associated courses: " + tempInstructor.getCourses());
+
+        System.out.println("DONE!");
+    }
+
+    private void findCoursesForInstructor(AppDAO appDAO) {
+
+        int theId = 2;
+
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+
+        // find courses for instructor
+        System.out.println("Finding courses for instructor id: " + theId);
+        List<Course> courses = appDAO.findCoursesByInstructor(theId);
+
+        // associate the objects
+        tempInstructor.setCourses(courses);
+
+        System.out.println("The associated courses: " + tempInstructor.getCourses());
+
+        System.out.println("DONE!");
+    }
+
+    private void findInstructorWithCourses(AppDAO appDAO) {
+
+        int theId = 2;
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        System.out.println("the associated courses: " + tempInstructor.getCourses());
+
+        System.out.println("DONE!");
+    }
+
+    private void createInstructorWithCourses(AppDAO appDAO) {
+
+        // create the instructor
+        Instructor tempInstructor =
+                new Instructor("Naresh", "Lohar", "naresh@krishna-bk.com.np");
+
+        // create the instructor detail
+        InstructorDetail tempInstructorDetail =
+                new InstructorDetail("https://www.youtube.com", "Music");
+
+        // create the courses
+        Course tempCourse1 = new Course("Air Guitar - The Ultimate Guide");
+        Course tempCourse2 = new Course("Basic of MUSIC");
+        Course tempCourse3 = new Course("The Pinball Masterclass");
+
+        // add courses to instructor
+        tempInstructor.add(tempCourse1);
+        tempInstructor.add(tempCourse2);
+        tempInstructor.add(tempCourse3);
+
+        // save the instructor
+        System.out.println("Saving instructor: " + tempInstructor);
+        System.out.println("The courses: " + tempInstructor.getCourses());
+        appDAO.save(tempInstructor);
+        System.out.println("DONE!");
+    }
+
+    private void deleteInstructorDetail(AppDAO appDAO) {
+
+        int theId = 3;
+        System.out.println("Deleting instructor id: " + theId);
+
+        appDAO.deleteInstructorDetailById(theId);
+
+        System.out.println("Done!");
+
+    }
+
+    private void findInstructorDetail(AppDAO appDAO) {
+
+        // get the instructor detail object
+        int theId = 1;
+        InstructorDetail tempInstructorDetail = appDAO.findInstructorDetailById(theId);
+
+        // print the instructor detail
+        System.out.println("tempInstructorDetail: " + tempInstructorDetail);
+
+        // print the associated instructor
+        System.out.println("The associated instructor: " + tempInstructorDetail.getInstructor());
+
+        System.out.println("Done!");
+    }
+
+    private void deleteInstructor(AppDAO appDAO) {
+
+        int theId = 2;
+        System.out.println("Deleting instructor id: " + theId);
+
+        appDAO.deleteInstructorById(theId);
+
+        System.out.println("Done!");
+    }
+
+    private void findInstructor(AppDAO appDAO) {
+        int theId = 1;
+        System.out.println("Finding Instructor id: " + theId);
+
+        Instructor tempInstructor  = appDAO.findInstructorById(theId);
+
+        System.out.println("tempInstructor: " + tempInstructor);
+        if (tempInstructor != null) {
+            System.out.println("the associated instructorDetail only: " + tempInstructor.getInstructorDetail());
+        } else {
+            System.out.println("Instructor not found with id: " + theId);
+        }
+    }
+
+    private void createInstructor(AppDAO appDAO) {
+
+        // create the instructor
+        Instructor tempInstructor = new Instructor(
+                "Krishna", "Bishowkarma", "hi@krishna-bk.com.np"
+        );
+
+        // create the instructor detail
+        InstructorDetail tempInstructorDetail = new InstructorDetail(
+                "https://www.youtube.com/@krishnabkarma","Filmmaking"
+        );
+
+        // associate the objects
+        tempInstructor.setInstructorDetail(tempInstructorDetail);
+
+        // save the objects
+        // NOTE: this will also save the details object because of CascadeType.ALL
+        System.out.println("Saving Instructor: " + tempInstructor);
+        appDAO.save(tempInstructor);
+        System.out.println("Done!");
+    }
+
+}

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -24,7 +24,9 @@ public class Application {
             // findCourseAndStudents(appDAO);
             // findStudentAndCourses(appDAO);
 
-            addMoreCoursesForStudents(appDAO);
+            // addMoreCoursesForStudents(appDAO);
+
+            deleteCourse(appDAO);
         };
     }
 

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -21,8 +21,21 @@ public class Application {
 
         return runner -> {
             //  createCourseAndStudents(appDAO);
-            findCourseAndStudents(appDAO);
+            // findCourseAndStudents(appDAO);
+            findStudentAndCourses(appDAO);
         };
+    }
+
+    private void findStudentAndCourses(AppDAO appDAO) {
+
+        int theId = 1;
+
+        Student tempStudent = appDAO.findStudentAndCourseByStudentId(theId);
+
+        System.out.println("Loaded student: " + tempStudent);
+        System.out.println("Courses: " + tempStudent.getCourses());
+
+        System.out.println("DONE!");
     }
 
     private void findCourseAndStudents(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -20,8 +20,22 @@ public class Application {
     public CommandLineRunner commandLineRunner(AppDAO appDAO){
 
         return runner -> {
-            createCourseAndStudents(appDAO);
+            //  createCourseAndStudents(appDAO);
+            findCourseAndStudents(appDAO);
         };
+    }
+
+    private void findCourseAndStudents(AppDAO appDAO) {
+
+        int theId = 10;
+
+        Course tempCourse = appDAO.findCourseAndStudentsByCourseId(theId);
+
+        System.out.println("Loaded course: " + tempCourse);
+        System.out.println("Students: " + tempCourse.getStudents());
+
+        System.out.println("DONE!");
+
     }
 
     private void createCourseAndStudents(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/Application.java
@@ -1,10 +1,7 @@
 package np.com.krishnabk.cruddemo;
 
 import np.com.krishnabk.cruddemo.dao.AppDAO;
-import np.com.krishnabk.cruddemo.entity.Course;
-import np.com.krishnabk.cruddemo.entity.Instructor;
-import np.com.krishnabk.cruddemo.entity.InstructorDetail;
-import np.com.krishnabk.cruddemo.entity.Review;
+import np.com.krishnabk.cruddemo.entity.*;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -23,8 +20,30 @@ public class Application {
     public CommandLineRunner commandLineRunner(AppDAO appDAO){
 
         return runner -> {
-
+            createCourseAndStudents(appDAO);
         };
+    }
+
+    private void createCourseAndStudents(AppDAO appDAO) {
+
+        // create course
+        Course tempCourse = new Course("Happy Path");
+
+        // crete the students
+        Student tempStudent1 = new Student("Bipasha", "Kafle", "bipasha@krishna-bk.com.np");
+        Student tempStudent2 = new Student("Bibechana", "Kafle", "bibechana@krishna-bk.com.np");
+
+        // add students to the course
+        tempCourse.addStudent(tempStudent1);
+        tempCourse.addStudent(tempStudent2);
+
+        // save the course and associated course
+        System.out.println("Saving the course: " + tempCourse);
+        System.out.println("associated students: " + tempCourse.getStudents());
+
+        appDAO.save(tempCourse);
+
+        System.out.println("DONE!");
     }
 
     private void deleteCourseAndReviews(AppDAO appDAO) {

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -1,0 +1,36 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import np.com.krishnabk.cruddemo.entity.Course;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+
+import java.util.List;
+
+public interface AppDAO {
+
+    void save(Instructor theInstructor);
+
+    Instructor findInstructorById(int theId);
+
+    void deleteInstructorById(int theId);
+
+    InstructorDetail findInstructorDetailById(int theId);
+
+    void deleteInstructorDetailById(int theId);
+
+    List<Course> findCoursesByInstructor(int theId);
+
+    Instructor findInstructorByIdJoinFetch(int theId);
+
+    void update(Instructor tempInstructor);
+
+    void update(Course tempCourse);
+
+    Course findCourseById(int theId);
+
+    void deleteCourseById(int theId);
+
+    void save(Course theCourse);
+
+    Course findCourseAndReviewByCourseId(int theId);
+}

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -40,4 +40,6 @@ public interface AppDAO {
     Student findStudentAndCourseByStudentId(int theId);
 
     void update(Student tempStudent);
+
+    void deleteStudentById(int theId);
 }

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -38,4 +38,6 @@ public interface AppDAO {
     Course findCourseAndStudentsByCourseId(int theId);
 
     Student findStudentAndCourseByStudentId(int theId);
+
+    void update(Student tempStudent);
 }

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -33,4 +33,6 @@ public interface AppDAO {
     void save(Course theCourse);
 
     Course findCourseAndReviewByCourseId(int theId);
+
+    Course findCourseAndStudentsByCourseId(int theId);
 }

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAO.java
@@ -3,6 +3,7 @@ package np.com.krishnabk.cruddemo.dao;
 import np.com.krishnabk.cruddemo.entity.Course;
 import np.com.krishnabk.cruddemo.entity.Instructor;
 import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+import np.com.krishnabk.cruddemo.entity.Student;
 
 import java.util.List;
 
@@ -35,4 +36,6 @@ public interface AppDAO {
     Course findCourseAndReviewByCourseId(int theId);
 
     Course findCourseAndStudentsByCourseId(int theId);
+
+    Student findStudentAndCourseByStudentId(int theId);
 }

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -1,0 +1,165 @@
+package np.com.krishnabk.cruddemo.dao;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import np.com.krishnabk.cruddemo.entity.Course;
+import np.com.krishnabk.cruddemo.entity.Instructor;
+import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Repository
+public class AppDAOImpl implements AppDAO{
+
+    // define field for entity manager
+    private EntityManager entityManager;
+
+    // inject entity manager using constructor injection
+    @Autowired
+    public AppDAOImpl(EntityManager entityManager){
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    @Transactional
+    public void save(Instructor theInstructor) {
+        entityManager.persist(theInstructor);
+
+    }
+
+    @Override
+    public Instructor findInstructorById(int theId) {
+        return entityManager.find(Instructor.class, theId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteInstructorById(int theId) {
+
+        // retrieve the instructor
+        Instructor tempInstructor = entityManager.find(Instructor.class, theId);
+
+        // get the courses
+        List<Course> courses = tempInstructor.getCourses();
+
+        // break association of all courses for the instructor
+        for(Course tempCourse : courses){
+            tempCourse.setInstructor(null);
+        }
+
+        // delete the instructor if found
+        entityManager.remove(tempInstructor);
+    }
+
+    @Override
+    public InstructorDetail findInstructorDetailById(int theId) {
+
+        return entityManager.find(InstructorDetail.class, theId);
+
+    }
+
+    @Override
+    @Transactional
+    public void deleteInstructorDetailById(int theId) {
+
+        // retrieve the instructor detail
+        InstructorDetail tempInstructorDetail = entityManager.find(InstructorDetail.class, theId);
+
+        // remove the associated object reference
+
+        // break bi-directional link
+
+        tempInstructorDetail.getInstructor().setInstructorDetail(null);
+
+        // delete the instructor detail
+        if(tempInstructorDetail != null){
+            entityManager.remove(tempInstructorDetail);
+        } else System.out.println("Instructor ID not found!");
+    }
+
+    @Override
+    public List<Course> findCoursesByInstructor(int theId) {
+
+        // create query
+        TypedQuery<Course> query = entityManager.createQuery(
+                "from Course where instructor.id = :data", Course.class);
+
+        query.setParameter("data", theId);
+
+        // execute the query
+        List<Course> courses = query.getResultList();
+
+        return courses;
+    }
+
+    @Override
+    public Instructor findInstructorByIdJoinFetch(int theId) {
+
+        // create query
+        TypedQuery<Instructor> query =  entityManager.createQuery(
+                "select i from Instructor  i "
+                + "JOIN  FETCH i.courses "
+                + "where i.id = :data", Instructor.class);
+
+        query.setParameter("data", theId);
+
+        // execute query
+        Instructor instructor = query.getSingleResult();
+
+        return instructor;
+
+    }
+
+    @Override
+    @Transactional
+    public void update(Instructor tempInstructor) {
+        entityManager.merge(tempInstructor);
+    }
+
+    @Override
+    @Transactional
+    public void update(Course tempCourse) {
+        entityManager.merge(tempCourse);
+    }
+
+    @Override
+    public Course findCourseById(int theId) {
+        return entityManager.find(Course.class, theId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteCourseById(int theId) {
+
+        // retrieve the course
+        Course tempCourse = entityManager.find(Course.class, theId);
+
+        // delete the course
+        entityManager.remove(tempCourse);
+
+    }
+
+    @Override
+    @Transactional
+    public void save(Course theCourse) {
+
+        entityManager.persist(theCourse);
+    }
+
+    @Override
+    public Course findCourseAndReviewByCourseId(int theId) {
+
+        // create query
+        TypedQuery<Course> query = entityManager.createQuery(
+                "select c from Course c "
+                        + "JOIN FETCH c.reviews "
+                        + "where c.id = :data", Course.class);
+        query.setParameter("data", theId);
+        // execute query
+        Course course = query.getSingleResult();
+        return course;
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -5,6 +5,7 @@ import jakarta.persistence.TypedQuery;
 import np.com.krishnabk.cruddemo.entity.Course;
 import np.com.krishnabk.cruddemo.entity.Instructor;
 import np.com.krishnabk.cruddemo.entity.InstructorDetail;
+import np.com.krishnabk.cruddemo.entity.Student;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -177,5 +178,21 @@ public class AppDAOImpl implements AppDAO{
         Course course = query.getSingleResult();
 
         return course;
+    }
+
+    @Override
+    public Student findStudentAndCourseByStudentId(int theId) {
+
+        // create query
+        TypedQuery<Student> query = entityManager.createQuery(
+                "select s from Student  s "
+                + "JOIN FETCH s.courses "
+                + "where s.id = :data", Student.class);
+        query.setParameter("data", theId);
+
+        // execute query
+        Student student = query.getSingleResult();
+
+        return student;
     }
 }

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -195,4 +195,10 @@ public class AppDAOImpl implements AppDAO{
 
         return student;
     }
+
+    @Override
+    @Transactional
+    public void update(Student tempStudent) {
+            entityManager.merge(tempStudent);
+    }
 }

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -162,4 +162,20 @@ public class AppDAOImpl implements AppDAO{
         Course course = query.getSingleResult();
         return course;
     }
+
+    @Override
+    public Course findCourseAndStudentsByCourseId(int theId) {
+
+        // create query
+        TypedQuery<Course> query = entityManager.createQuery(
+                "select c from Course c "
+                        + "JOIN FETCH c.students "
+                        + "where c.id = :data", Course.class);
+        query.setParameter("data", theId);
+
+        // execute query
+        Course course = query.getSingleResult();
+
+        return course;
+    }
 }

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/dao/AppDAOImpl.java
@@ -201,4 +201,27 @@ public class AppDAOImpl implements AppDAO{
     public void update(Student tempStudent) {
             entityManager.merge(tempStudent);
     }
+
+    @Override
+    @Transactional
+    public void deleteStudentById(int theId) {
+
+        // retrieve the student
+        Student tempStudent = entityManager.find(Student.class, theId);
+
+        if (tempStudent != null){
+
+            // get the course
+            List<Course> courses = tempStudent.getCourses();
+
+            // break association of all courses for the student
+            for (Course tempCourse : courses){
+                tempCourse.getStudents().remove(tempStudent);
+            }
+
+            // now delete the student
+            entityManager.remove(tempStudent);
+
+        }
+    }
 }

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
@@ -1,0 +1,91 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "course")
+public class Course {
+
+    // define fields
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "title")
+    private String title;
+
+    @ManyToOne(cascade = {CascadeType.DETACH, CascadeType.MERGE,
+                            CascadeType.PERSIST, CascadeType.REFRESH})
+    @JoinColumn(name = "instructor_id")
+    private Instructor instructor;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "course_id")
+    private List<Review> reviews;
+
+    // define constructors
+    public Course(){}
+
+    public Course(String title) {
+        this.title = title;
+    }
+
+    // define getters and setters
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Instructor getInstructor() {
+        return instructor;
+    }
+
+    public void setInstructor(Instructor instructor) {
+        this.instructor = instructor;
+    }
+
+    public List<Review> getReviews() {
+        return reviews;
+    }
+
+    public void setReviews(List<Review> reviews) {
+        this.reviews = reviews;
+    }
+
+    // add convenience method
+
+    public void addReview(Review theReview){
+
+        if(reviews == null){
+            reviews = new ArrayList<>();
+        }
+
+        reviews.add(theReview);
+    }
+
+    // define toString()
+
+    @Override
+    public String toString() {
+        return "Course{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Course.java
@@ -27,6 +27,16 @@ public class Course {
     @JoinColumn(name = "course_id")
     private List<Review> reviews;
 
+    @ManyToMany(fetch = FetchType.LAZY,
+            cascade = {CascadeType.DETACH, CascadeType.MERGE,
+            CascadeType.PERSIST, CascadeType.REFRESH})
+    @JoinTable(
+            name = "course_student",
+            joinColumns = @JoinColumn(name = "course_id"),
+            inverseJoinColumns = @JoinColumn(name = "student_id")
+    )
+    private List<Student> students;
+
     // define constructors
     public Course(){}
 
@@ -68,6 +78,14 @@ public class Course {
         this.reviews = reviews;
     }
 
+    public List<Student> getStudents() {
+        return students;
+    }
+
+    public void setStudents(List<Student> students) {
+        this.students = students;
+    }
+
     // add convenience method
 
     public void addReview(Review theReview){
@@ -77,6 +95,14 @@ public class Course {
         }
 
         reviews.add(theReview);
+    }
+
+    public void addStudent(Student theStudent){
+        if(students == null){
+            students = new ArrayList<>();
+        }
+
+        students.add(theStudent);
     }
 
     // define toString()

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Instructor.java
@@ -1,0 +1,128 @@
+    package np.com.krishnabk.cruddemo.entity;
+
+    import jakarta.persistence.*;
+
+    import java.util.ArrayList;
+    import java.util.List;
+
+    @Entity
+    @Table(name = "instructor")
+    public class Instructor {
+
+        // step 1. annotate the class as an entity and map to db table
+
+        // step 2. define table fields
+
+        // step 3. annotate the fields with db column names
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "id")
+        private int id;
+
+        @Column(name = "first_name")
+        private String firstName;
+
+        @Column(name = "last_name")
+        private String lastName;
+
+        @Column(name = "email")
+        private String email;
+
+        // set up mapping to InstructorDetail entity
+
+        @OneToOne(cascade = CascadeType.ALL)
+        @JoinColumn(name = "instructor_detail_id")
+        private InstructorDetail instructorDetail;
+
+        @OneToMany(mappedBy = "instructor",
+                    fetch = FetchType.LAZY,
+                    cascade = {CascadeType.DETACH, CascadeType.MERGE,
+                            CascadeType.PERSIST, CascadeType.REFRESH})
+        private List<Course> courses;
+
+        // step 4. create constructors
+
+        public Instructor(){}
+
+        public Instructor(String firstName, String lastName, String email) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.email = email;
+        }
+
+        // step 5. generate getters/setters methods
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
+        public InstructorDetail getInstructorDetail() {
+            return instructorDetail;
+        }
+
+        public void setInstructorDetail(InstructorDetail instructorDetail) {
+            this.instructorDetail = instructorDetail;
+        }
+
+        public List<Course> getCourses() {
+            return courses;
+        }
+
+        public void setCourses(List<Course> courses) {
+            this.courses = courses;
+        }
+
+        // step 6. generate toString() method
+
+        @Override
+        public String toString() {
+            return "Instructor{" +
+                    "id=" + id +
+                    ", firstName='" + firstName + '\'' +
+                    ", lastName='" + lastName + '\'' +
+                    ", email='" + email + '\'' +
+                    ", instructorDetail=" + instructorDetail +
+                    '}';
+        }
+
+        // add convenience method for bidirectional relationship
+
+        public void add(Course tempCourse){
+            if (courses == null){
+                courses = new ArrayList<>();
+            }
+
+            courses.add(tempCourse);
+
+            tempCourse.setInstructor(this);
+        }
+    }

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/InstructorDetail.java
@@ -1,0 +1,83 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "instructor_detail")
+public class InstructorDetail {
+
+
+    // step 1. annotate the class as an entity and map to db table
+    // step 2. define table fields
+    // step 3. annotate the fields with db column names
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "youtube_channel")
+    private String youtubeChannel;
+
+    @Column(name = "hobby")
+    private String hobby;
+
+    // add @OneToOne annotation
+    @OneToOne(mappedBy = "instructorDetail", cascade = {CascadeType.DETACH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH})
+    private Instructor instructor;
+
+
+    // step 4. create constructors
+    public InstructorDetail(){
+
+    }
+
+    public InstructorDetail(String youtubeChannel, String hobby) {
+        this.youtubeChannel = youtubeChannel;
+        this.hobby = hobby;
+    }
+
+    // step 5. generate getters/setters methods
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getYoutubeChannel() {
+        return youtubeChannel;
+    }
+
+    public void setYoutubeChannel(String youtubeChannel) {
+        this.youtubeChannel = youtubeChannel;
+    }
+
+    public String getHobby() {
+        return hobby;
+    }
+
+    public void setHobby(String hobby) {
+        this.hobby = hobby;
+    }
+
+    public Instructor getInstructor() {
+        return instructor;
+    }
+
+    public void setInstructor(Instructor instructor) {
+        this.instructor = instructor;
+    }
+
+    // step 6. generate toString() method
+
+    @Override
+    public String toString() {
+        return "InstructorDetail{" +
+                "id=" + id +
+                ", youtubeChannel='" + youtubeChannel + '\'' +
+                ", hobby='" + hobby + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Review.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Review.java
@@ -1,0 +1,52 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "review")
+public class Review {
+
+    // define fields
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "comment")
+    private String comment;
+
+    // define constructors
+    public Review(){}
+
+    public Review(String comment) {
+        this.comment = comment;
+    }
+
+    // define getters/setters
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    // define toString
+
+    @Override
+    public String toString() {
+        return "Review{" +
+                "id=" + id +
+                ", comment='" + comment + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Student.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Student.java
@@ -1,0 +1,72 @@
+package np.com.krishnabk.cruddemo.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "student")
+public class Student {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "first_name")
+    private String firstName;
+
+    @Column(name = "last_name")
+    private String lastName;
+
+    @Column(name = "email")
+    private String email;
+
+    public Student(){}
+
+    public Student(String firstName, String lastName, String email) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.email = email;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    @Override
+    public String toString() {
+        return "Student{" +
+                "id=" + id +
+                ", firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", email='" + email + '\'' +
+                '}';
+    }
+}

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Student.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/java/np/com/krishnabk/cruddemo/entity/Student.java
@@ -2,6 +2,9 @@ package np.com.krishnabk.cruddemo.entity;
 
 import jakarta.persistence.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "student")
 public class Student {
@@ -19,6 +22,12 @@ public class Student {
 
     @Column(name = "email")
     private String email;
+
+    @ManyToMany(fetch = FetchType.LAZY,
+            cascade = {CascadeType.DETACH, CascadeType.MERGE,
+                    CascadeType.PERSIST, CascadeType.REFRESH},
+            mappedBy = "students")
+    private List<Course> courses;
 
     public Student(){}
 
@@ -58,6 +67,25 @@ public class Student {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public List<Course> getCourses() {
+        return courses;
+    }
+
+    public void setCourses(List<Course> courses) {
+        this.courses = courses;
+    }
+
+    // add convenience method
+    public void addCourse(Course theCourse){
+
+        if(courses == null){
+            courses = new ArrayList<>();
+        }
+
+        courses.add(theCourse);
+        theCourse.addStudent(this);
     }
 
     @Override

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/resources/application.properties
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+spring.application.name=05-jpa-many-to-many
+spring.datasource.url=jdbc:mysql://localhost:3306/hb-05-many-to-many
+spring.datasource.username=springstudent
+spring.datasource.password=springstudent
+
+# Turn off the Spring Boot Banner
+spring.main.banner-mode=off
+
+# Reduce logging level. Set logging level to warn
+logging.level.root=warn
+
+
+# Show JPA/Hibernate logging message
+logging.level.org.hibernate.sql=trace
+logging.level.org.hibernate.orm.jdbc.bind=trace

--- a/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/test/java/np/com/krishnabk/cruddemo/ApplicationTests.java
+++ b/09-spring-boot-jpa-advanced-mappings/05-jpa-many-to-many/src/test/java/np/com/krishnabk/cruddemo/ApplicationTests.java
@@ -1,0 +1,13 @@
+package np.com.krishnabk.cruddemo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}


### PR DESCRIPTION

- Summary
  - Add Student entity and wire up a bidirectional `@ManyToMany` between Course and Student using join table `course_student`.
  - Add helper methods to create sample data (createCourseAndStudents) and convenience addX methods on entities.
  - Extend DAO with findCourseAndStudentsByCourseId(...) (JOIN FETCH) and deleteStudentById(...) which removes associations before deleting.
  - Update application runner to demonstrate fetch and delete flows.

- Why
  - Provide working many-to-many example, retrieval with joined fetch, and safe student deletion that cleans up association state.

- Notable changes
  - Entities: Course, Student (many-to-many mapping, lazy fetch, cascade {DETACH, MERGE, PERSIST, REFRESH})
  - DAO: AppDAO + AppDAOImpl (new fetch and delete methods)
  - Application/CommandLineRunner: demo calls for creating, fetching, and deleting students/courses

- Migration / Backwards-compatibility
  - Non-breaking; adds new behavior and DAO methods. Database adds `course_student` join table when schema is updated.

- Testing / Validation
  - CommandLineRunner demonstrates create, fetch (JOIN FETCH), and delete flows — run app to verify.